### PR TITLE
Fix container mode bypass: reject unknown launcher modes

### DIFF
--- a/.gsd/.current-feature
+++ b/.gsd/.current-feature
@@ -1,1 +1,1 @@
-zerg-help-flag
+container-mode-bypass

--- a/.gsd/specs/container-mode-bypass/design.md
+++ b/.gsd/specs/container-mode-bypass/design.md
@@ -1,0 +1,75 @@
+# Technical Design: container-mode-bypass
+
+## Metadata
+- **Feature**: container-mode-bypass
+- **Status**: APPROVED
+- **Created**: 2026-01-31
+- **Source**: GitHub Issue #2
+
+## 1. Overview
+
+### 1.1 Summary
+Remove the unimplemented "task" launcher mode from CLI choices, make unknown modes fail loudly with `ValueError`, and add launcher mode logging/console output so users can confirm which mode is active.
+
+### 1.2 Goals
+- Eliminate silent fallback for unknown launcher modes
+- Provide user-visible confirmation of launcher mode
+- Prevent future confusion about supported modes
+
+### 1.3 Non-Goals
+- Implementing a TaskLauncher (separate feature if needed)
+- Changing container or subprocess launcher behavior
+
+## 2. Architecture
+
+### 2.1 Data Flow
+
+```
+CLI (rush.py)                    Orchestrator._create_launcher()
+  --mode {choice} ──────────────▶  mode dispatch:
+  choices: subprocess,               subprocess → SubprocessLauncher
+           container,                 container  → ContainerLauncher
+           auto                       auto       → auto-detect
+                                      unknown    → ValueError (NEW)
+                                    ──────────────▶ logger.info(mode selected)
+                                    ──────────────▶ console.print(launcher type)
+```
+
+### 2.2 Key Decision
+
+**Decision**: Remove "task" from CLI rather than implement TaskLauncher.
+
+**Rationale**: "task" mode has no implementation, no design, and no tests. Adding a stub would be scope creep. Remove it now; add it back with a proper implementation later if needed.
+
+## 3. Implementation Plan
+
+| Phase | Tasks | Parallel | Files |
+|-------|-------|----------|-------|
+| L1: Fix | 2 tasks | Yes | rush.py, orchestrator.py |
+| L2: Docs + Tests | 2 tasks | Yes | rush.core.md, test files |
+
+### File Ownership
+
+| File | Task ID | Operation |
+|------|---------|-----------|
+| zerg/commands/rush.py | TASK-001 | modify |
+| zerg/orchestrator.py | TASK-002 | modify |
+| zerg/data/commands/rush.core.md | TASK-003 | modify |
+| tests/unit/test_orchestrator_container_mode.py | TASK-004 | modify |
+
+## 4. Risk Assessment
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| Plugin launchers affected by ValueError | Low | Med | Plugin path checked before else branch |
+| Existing tests break | Low | Low | Run full suite before commit |
+
+## 5. Verification
+
+```bash
+pytest tests/unit/test_orchestrator_container_mode.py tests/unit/test_rush_cmd.py -v
+pytest tests/ -x -q
+```
+
+## 6. Recommended Workers
+- Optimal: 2 workers (L1 tasks parallel, L2 tasks parallel)

--- a/.gsd/specs/container-mode-bypass/requirements.md
+++ b/.gsd/specs/container-mode-bypass/requirements.md
@@ -1,0 +1,20 @@
+# Requirements: container-mode-bypass
+
+## Metadata
+- **Feature**: container-mode-bypass
+- **Status**: APPROVED
+- **Source**: GitHub Issue #2
+- **Priority**: P0 Critical
+
+## Problem
+
+`--mode task` is accepted by CLI but has no launcher implementation. Unknown modes silently fall back to subprocess via config default. No user feedback confirms which launcher mode was actually used.
+
+## Requirements
+
+1. Remove unimplemented `"task"` from CLI mode choices
+2. Raise `ValueError` for unknown modes instead of silent fallback
+3. Log selected launcher mode after resolution
+4. Print launcher type to console after Orchestrator init
+5. Update slash command help text to match
+6. Add tests for unknown mode rejection

--- a/.gsd/specs/container-mode-bypass/task-graph.json
+++ b/.gsd/specs/container-mode-bypass/task-graph.json
@@ -1,0 +1,106 @@
+{
+  "feature": "container-mode-bypass",
+  "version": "2.0",
+  "generated": "2026-01-31T21:30:00Z",
+  "total_tasks": 4,
+  "estimated_duration_minutes": 20,
+  "max_parallelization": 2,
+  "critical_path_minutes": 15,
+  "tasks": [
+    {
+      "id": "TASK-001",
+      "title": "Remove task mode from CLI and add launcher confirmation",
+      "description": "In rush.py: remove 'task' from click.Choice on --mode option (line 37). After Orchestrator init (~line 158), add console.print showing the launcher class name.",
+      "phase": "fix",
+      "level": 1,
+      "dependencies": [],
+      "files": {
+        "create": [],
+        "modify": ["zerg/commands/rush.py"],
+        "read": []
+      },
+      "verification": {
+        "command": "python -c \"from zerg.commands.rush import rush; print('import ok')\"",
+        "timeout_seconds": 30
+      },
+      "estimate_minutes": 5,
+      "skills_required": ["python", "click"]
+    },
+    {
+      "id": "TASK-002",
+      "title": "Raise ValueError for unknown modes and add launcher logging",
+      "description": "In orchestrator.py _create_launcher() (lines 255-260): replace silent config fallback in else branch with ValueError('Unsupported launcher mode: {mode}'). Add logger.info after mode resolution (before line 262) showing selected launcher_type.",
+      "phase": "fix",
+      "level": 1,
+      "dependencies": [],
+      "files": {
+        "create": [],
+        "modify": ["zerg/orchestrator.py"],
+        "read": []
+      },
+      "verification": {
+        "command": "python -c \"from zerg.orchestrator import Orchestrator; print('import ok')\"",
+        "timeout_seconds": 30
+      },
+      "estimate_minutes": 5,
+      "skills_required": ["python"]
+    },
+    {
+      "id": "TASK-003",
+      "title": "Update rush.core.md help text",
+      "description": "In rush.core.md line 230: change '--mode MODE  Execution mode: container|subprocess' to '--mode MODE  Execution mode: subprocess|container|auto'",
+      "phase": "docs",
+      "level": 2,
+      "dependencies": ["TASK-001"],
+      "files": {
+        "create": [],
+        "modify": ["zerg/data/commands/rush.core.md"],
+        "read": []
+      },
+      "verification": {
+        "command": "grep -q 'subprocess|container|auto' zerg/data/commands/rush.core.md",
+        "timeout_seconds": 10
+      },
+      "estimate_minutes": 2,
+      "skills_required": ["markdown"]
+    },
+    {
+      "id": "TASK-004",
+      "title": "Add tests for unknown mode rejection",
+      "description": "In test_orchestrator_container_mode.py: add TestUnknownModeRejection class with two tests: (1) test_unknown_mode_raises_value_error — passing mode='bogus' raises ValueError, (2) test_task_mode_raises_value_error — passing mode='task' raises ValueError. Both follow existing patch pattern in the file.",
+      "phase": "testing",
+      "level": 2,
+      "dependencies": ["TASK-002"],
+      "files": {
+        "create": [],
+        "modify": ["tests/unit/test_orchestrator_container_mode.py"],
+        "read": []
+      },
+      "verification": {
+        "command": "python -m pytest tests/unit/test_orchestrator_container_mode.py -v --tb=short",
+        "timeout_seconds": 60
+      },
+      "estimate_minutes": 10,
+      "skills_required": ["python", "pytest"]
+    }
+  ],
+  "levels": {
+    "1": {
+      "name": "fix",
+      "tasks": ["TASK-001", "TASK-002"],
+      "parallel": true,
+      "estimated_minutes": 5
+    },
+    "2": {
+      "name": "docs-and-tests",
+      "tasks": ["TASK-003", "TASK-004"],
+      "parallel": true,
+      "estimated_minutes": 10,
+      "depends_on_levels": [1]
+    }
+  },
+  "conflict_matrix": {
+    "description": "No conflicts — each task owns exclusive files",
+    "conflicts": []
+  }
+}

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -174,18 +174,16 @@ class TestLauncherCreation:
         mock_orchestrator_deps["container_launcher_mock"].assert_called()
         mock_orchestrator_deps["container_launcher"].ensure_network.assert_called()
 
-    def test_create_launcher_unknown_mode_uses_config(
+    def test_create_launcher_unknown_mode_raises_value_error(
         self, mock_orchestrator_deps, tmp_path: Path, monkeypatch
     ) -> None:
-        """Test unknown mode falls back to config setting."""
+        """Test unknown mode raises ValueError instead of silent fallback."""
         monkeypatch.chdir(tmp_path)
         (tmp_path / ".zerg").mkdir()
 
         config = ZergConfig()
-        orch = Orchestrator("test-feature", config=config, launcher_mode="unknown_mode")
-
-        # Should use config's get_launcher_type
-        assert orch.launcher is not None
+        with pytest.raises(ValueError, match="Unsupported launcher mode"):
+            Orchestrator("test-feature", config=config, launcher_mode="unknown_mode")
 
     def test_create_launcher_auto_mode_no_devcontainer(
         self, mock_orchestrator_deps, tmp_path: Path, monkeypatch

--- a/tests/unit/test_orchestrator_container_mode.py
+++ b/tests/unit/test_orchestrator_container_mode.py
@@ -552,3 +552,75 @@ class TestContainerModeEnforcement:
         # Should have fallen back to subprocess
         mock_subprocess_launcher_class.assert_called_once()
         assert orch.launcher is mock_subprocess_instance
+
+
+class TestUnknownModeRejection:
+    """Tests that unknown launcher modes raise ValueError instead of silent fallback."""
+
+    @patch("zerg.orchestrator.StateManager")
+    @patch("zerg.orchestrator.LevelController")
+    @patch("zerg.orchestrator.TaskParser")
+    @patch("zerg.orchestrator.GateRunner")
+    @patch("zerg.orchestrator.WorktreeManager")
+    @patch("zerg.orchestrator.ContainerManager")
+    @patch("zerg.orchestrator.PortAllocator")
+    @patch("zerg.orchestrator.MergeCoordinator")
+    @patch("zerg.orchestrator.TaskSyncBridge")
+    @patch("zerg.orchestrator.SubprocessLauncher")
+    def test_unknown_mode_raises_value_error(
+        self,
+        mock_subprocess_launcher_class: MagicMock,
+        mock_task_sync: MagicMock,
+        mock_merge_coordinator: MagicMock,
+        mock_port_allocator: MagicMock,
+        mock_container_manager: MagicMock,
+        mock_worktree_manager: MagicMock,
+        mock_gate_runner: MagicMock,
+        mock_task_parser: MagicMock,
+        mock_level_controller: MagicMock,
+        mock_state_manager: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Unknown launcher mode must raise ValueError, not silently fall back."""
+        config = ZergConfig()
+        with pytest.raises(ValueError, match="Unsupported launcher mode: 'bogus'"):
+            Orchestrator(
+                feature="test-feature",
+                config=config,
+                repo_path=tmp_path,
+                launcher_mode="bogus",
+            )
+
+    @patch("zerg.orchestrator.StateManager")
+    @patch("zerg.orchestrator.LevelController")
+    @patch("zerg.orchestrator.TaskParser")
+    @patch("zerg.orchestrator.GateRunner")
+    @patch("zerg.orchestrator.WorktreeManager")
+    @patch("zerg.orchestrator.ContainerManager")
+    @patch("zerg.orchestrator.PortAllocator")
+    @patch("zerg.orchestrator.MergeCoordinator")
+    @patch("zerg.orchestrator.TaskSyncBridge")
+    @patch("zerg.orchestrator.SubprocessLauncher")
+    def test_task_mode_raises_value_error(
+        self,
+        mock_subprocess_launcher_class: MagicMock,
+        mock_task_sync: MagicMock,
+        mock_merge_coordinator: MagicMock,
+        mock_port_allocator: MagicMock,
+        mock_container_manager: MagicMock,
+        mock_worktree_manager: MagicMock,
+        mock_gate_runner: MagicMock,
+        mock_task_parser: MagicMock,
+        mock_level_controller: MagicMock,
+        mock_state_manager: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """The removed 'task' mode must raise ValueError if somehow passed."""
+        config = ZergConfig()
+        with pytest.raises(ValueError, match="Unsupported launcher mode: 'task'"):
+            Orchestrator(
+                feature="test-feature",
+                config=config,
+                repo_path=tmp_path,
+                launcher_mode="task",
+            )

--- a/zerg/commands/rush.py
+++ b/zerg/commands/rush.py
@@ -34,7 +34,7 @@ logger = get_logger("rush")
 @click.option("--task-graph", "-g", help="Path to task-graph.json")
 @click.option(
     "--mode", "-m",
-    type=click.Choice(["subprocess", "container", "task", "auto"]),
+    type=click.Choice(["subprocess", "container", "auto"]),
     default="auto",
     help="Worker execution mode (default: auto-detect)",
 )
@@ -156,6 +156,8 @@ def rush(
 
         # Create orchestrator and start
         orchestrator = Orchestrator(feature, config, launcher_mode=mode)
+        launcher_name = type(orchestrator.launcher).__name__
+        console.print(f"Launcher: [bold]{launcher_name}[/bold]")
 
         # Register task completion callback with backlog update
         backlog_path = Path(f"tasks/{feature.upper()}-BACKLOG.md")

--- a/zerg/data/commands/rush.core.md
+++ b/zerg/data/commands/rush.core.md
@@ -227,7 +227,7 @@ When `--help` is passed in `$ARGUMENTS`, display usage and exit:
 Flags:
   --workers N           Number of workers to launch (default: 5, max: 10)
   --resume              Resume a previous run, skipping completed tasks
-  --mode MODE           Execution mode: container|subprocess
+  --mode MODE           Execution mode: subprocess|container|auto (default: auto)
   --help                Show this help message
 ```
 

--- a/zerg/orchestrator.py
+++ b/zerg/orchestrator.py
@@ -257,7 +257,12 @@ class Orchestrator:
             if plugin_launcher is not None:
                 logger.info(f"Using plugin launcher: {mode}")
                 return plugin_launcher
-            launcher_type = self.config.get_launcher_type()
+            raise ValueError(
+                f"Unsupported launcher mode: '{mode}'. "
+                f"Valid modes: subprocess, container, auto"
+            )
+
+        logger.info(f"Launcher mode resolved: {mode!r} → {launcher_type.value}")
 
         config = LauncherConfig(
             launcher_type=launcher_type,


### PR DESCRIPTION
## Summary

- Remove unimplemented `"task"` from `--mode` CLI choices (only `subprocess`, `container`, `auto` remain)
- Raise `ValueError` for unknown launcher modes instead of silently falling back to subprocess via config default
- Add `logger.info` showing resolved launcher mode after mode selection
- Print launcher class name to console after Orchestrator init for user confirmation
- Update `/zerg:rush` help text to reflect valid modes

Closes #2

## Test plan

- [x] New tests: `TestUnknownModeRejection` — 2 tests for unknown and "task" modes raising `ValueError`
- [x] Updated test: `test_create_launcher_unknown_mode_raises_value_error` (was `_uses_config`)
- [x] All 14 container mode tests pass
- [x] All 72 rush + orchestrator tests pass
- [x] Full suite: 5538 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)