### PR TITLE
Show human-friendly launcher mode and worker count in rush output

### DIFF
--- a/.gsd/.current-feature
+++ b/.gsd/.current-feature
@@ -1,1 +1,1 @@
-container-mode-bypass
+launcher-mode-verification

--- a/.gsd/specs/launcher-mode-verification/design.md
+++ b/.gsd/specs/launcher-mode-verification/design.md
@@ -1,0 +1,51 @@
+# Technical Design: launcher-mode-verification
+
+## Metadata
+- **Feature**: launcher-mode-verification
+- **Status**: APPROVED
+- **Created**: 2026-01-31
+
+## 1. Overview
+
+Enhance rush output to show human-friendly launcher mode and worker count at start and in completion summary.
+
+## 2. Changes
+
+### 2.1 `zerg/commands/rush.py` (~lines 159-160, 188-196)
+
+**Start output** — replace:
+```python
+launcher_name = type(orchestrator.launcher).__name__
+console.print(f"Launcher: [bold]{launcher_name}[/bold]")
+```
+With:
+```python
+launcher_name = type(orchestrator.launcher).__name__
+mode_label = "container (Docker)" if "Container" in launcher_name else "subprocess"
+console.print(f"Launcher mode: [bold]{mode_label}[/bold]")
+console.print(f"Workers: [bold]{workers}[/bold]")
+```
+
+**Completion output** — add mode to summary:
+```python
+if status["is_complete"]:
+    console.print(f"\n[bold green]✓ All tasks complete![/bold green] (mode: {mode_label})")
+```
+
+### 2.2 Tests — `tests/unit/test_rush_cmd.py`
+
+Update any assertions that check for the old "Launcher:" output format.
+
+## 3. File Ownership
+
+| File | Task ID | Operation |
+|------|---------|-----------|
+| zerg/commands/rush.py | TASK-001 | modify |
+| tests/unit/test_rush_cmd.py | TASK-002 | modify |
+
+## 4. Verification
+
+```bash
+pytest tests/unit/test_rush_cmd.py -v
+pytest tests/ -x -q
+```

--- a/.gsd/specs/launcher-mode-verification/requirements.md
+++ b/.gsd/specs/launcher-mode-verification/requirements.md
@@ -1,0 +1,17 @@
+# Requirements: launcher-mode-verification
+
+## Metadata
+- **Feature**: launcher-mode-verification
+- **Status**: APPROVED
+- **Source**: GitHub Issue #3
+- **Priority**: P1 High
+
+## Problem
+
+After rush completes, there is no human-friendly confirmation of which launcher mode was used. The #2 fix added a class name print (`ContainerLauncher`/`SubprocessLauncher`) but the issue expects a user-friendly format with worker count.
+
+## Requirements
+
+1. Replace class name display with human-friendly mode label (e.g., "container (Docker)", "subprocess")
+2. Show worker count alongside launcher mode
+3. Include launcher mode in completion summary

--- a/.gsd/specs/launcher-mode-verification/task-graph.json
+++ b/.gsd/specs/launcher-mode-verification/task-graph.json
@@ -1,0 +1,68 @@
+{
+  "feature": "launcher-mode-verification",
+  "version": "2.0",
+  "generated": "2026-01-31T22:00:00Z",
+  "total_tasks": 2,
+  "estimated_duration_minutes": 10,
+  "max_parallelization": 1,
+  "critical_path_minutes": 10,
+  "tasks": [
+    {
+      "id": "TASK-001",
+      "title": "Enhance rush launcher mode output",
+      "description": "Replace class name display with human-friendly mode label and worker count. Add mode to completion summary.",
+      "phase": "fix",
+      "level": 1,
+      "dependencies": [],
+      "files": {
+        "create": [],
+        "modify": ["zerg/commands/rush.py"],
+        "read": []
+      },
+      "verification": {
+        "command": "python -c \"from zerg.commands.rush import rush; print('ok')\"",
+        "timeout_seconds": 30
+      },
+      "estimate_minutes": 5,
+      "skills_required": ["python"]
+    },
+    {
+      "id": "TASK-002",
+      "title": "Update rush tests for new output format",
+      "description": "Update any test assertions checking for old 'Launcher:' output to match new 'Launcher mode:' format.",
+      "phase": "testing",
+      "level": 2,
+      "dependencies": ["TASK-001"],
+      "files": {
+        "create": [],
+        "modify": ["tests/unit/test_rush_cmd.py"],
+        "read": []
+      },
+      "verification": {
+        "command": "python -m pytest tests/unit/test_rush_cmd.py -v --tb=short",
+        "timeout_seconds": 60
+      },
+      "estimate_minutes": 5,
+      "skills_required": ["python", "pytest"]
+    }
+  ],
+  "levels": {
+    "1": {
+      "name": "fix",
+      "tasks": ["TASK-001"],
+      "parallel": false,
+      "estimated_minutes": 5
+    },
+    "2": {
+      "name": "testing",
+      "tasks": ["TASK-002"],
+      "parallel": false,
+      "estimated_minutes": 5,
+      "depends_on_levels": [1]
+    }
+  },
+  "conflict_matrix": {
+    "description": "Sequential — TASK-002 depends on TASK-001",
+    "conflicts": []
+  }
+}

--- a/zerg/commands/rush.py
+++ b/zerg/commands/rush.py
@@ -157,7 +157,9 @@ def rush(
         # Create orchestrator and start
         orchestrator = Orchestrator(feature, config, launcher_mode=mode)
         launcher_name = type(orchestrator.launcher).__name__
-        console.print(f"Launcher: [bold]{launcher_name}[/bold]")
+        mode_label = "container (Docker)" if "Container" in launcher_name else "subprocess"
+        console.print(f"Launcher mode: [bold]{mode_label}[/bold]")
+        console.print(f"Workers: [bold]{workers}[/bold]")
 
         # Register task completion callback with backlog update
         backlog_path = Path(f"tasks/{feature.upper()}-BACKLOG.md")
@@ -188,7 +190,7 @@ def rush(
         # Show final status
         status = orchestrator.status()
         if status["is_complete"]:
-            console.print("\n[bold green]✓ All tasks complete![/bold green]")
+            console.print(f"\n[bold green]✓ All tasks complete![/bold green] (mode: {mode_label})")
         else:
             pct = status["progress"]["percent"]
             console.print(


### PR DESCRIPTION
## Summary

- Replace raw class name (`ContainerLauncher`/`SubprocessLauncher`) with human-friendly labels (`container (Docker)` / `subprocess`)
- Display worker count alongside launcher mode at start
- Include launcher mode in completion summary line

Closes #3

## Test plan

- [x] All 57 rush command tests pass
- [x] Full suite: 5538 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)