### PR TITLE
ci: enforce CHANGELOG.md updates on PRs

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,26 @@
+name: Changelog Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  check-changelog:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check CHANGELOG.md was updated
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -q '^CHANGELOG.md$'; then
+            echo "CHANGELOG.md was updated."
+          else
+            echo "::error::CHANGELOG.md was not updated. Add an entry under [Unreleased] or apply the 'skip-changelog' label."
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- GitHub Actions workflow to enforce CHANGELOG.md updates on PRs (skippable with `skip-changelog` label)
+- Claude Code instruction in CLAUDE.md to proactively update changelog when creating PRs
+
 ## [0.1.0] - 2026-01-31
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,17 @@ Use `/zerg:status` to view the CONTEXT BUDGET section showing:
 - Per-task context population rate
 - Security rule filtering stats
 
+## PR Documentation Rules
+
+When creating a pull request, **always update CHANGELOG.md** under the `[Unreleased]` section with a brief entry describing the change. Use the appropriate category:
+
+- **Added** — new features or capabilities
+- **Changed** — modifications to existing functionality
+- **Fixed** — bug fixes
+- **Removed** — removed features or deprecated code
+
+If the PR is trivial (typo fix, CI config, test-only), apply the `skip-changelog` label instead. A CI check enforces this — PRs without a CHANGELOG update or the `skip-changelog` label will fail.
+
 ## Troubleshooting
 
 Zerglings not starting? Check Docker, ANTHROPIC_API_KEY, and port availability.


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that checks PRs for CHANGELOG.md updates
- Skippable via `skip-changelog` label for trivial changes
- Add Claude Code instructions in CLAUDE.md to proactively update changelog

## Test plan
- [ ] Open a PR without CHANGELOG.md changes → CI should fail
- [ ] Add `skip-changelog` label → CI should pass
- [ ] Open a PR with CHANGELOG.md changes → CI should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)