### PR TITLE
fix: zerg status misreports feature lifecycle stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `zerg status` now distinguishes between planned, in-design, and designed-but-not-executing features instead of a single generic message
 - `zerg status` now shows "planned but not yet executed" instead of cryptic error for features with specs but no state
 - `zerg cleanup` now clears `.gsd/.current-feature` when it points to a cleaned feature
 - `zerg cleanup` now removes orphaned `.gsd/specs/{feature}/` directories

--- a/tests/unit/test_status_cmd.py
+++ b/tests/unit/test_status_cmd.py
@@ -273,8 +273,8 @@ class TestStatusCommand:
         result = runner.invoke(cli, ["status", "--feature", "my-feature"])
 
         assert result.exit_code != 0
-        assert "planned but not yet executed" in result.output.lower()
-        assert "zerg rush" in result.output.lower()
+        assert "planned but not yet designed" in result.output.lower()
+        assert "zerg design" in result.output.lower()
         assert "zerg cleanup" in result.output.lower()
 
     def test_status_basic_display(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:

--- a/zerg/commands/status.py
+++ b/zerg/commands/status.py
@@ -97,13 +97,41 @@ def status(
         if not state.exists():
             spec_dir = Path(SPECS_DIR) / feature
             if spec_dir.exists():
-                console.print(
-                    f"[yellow]Feature '{feature}' is planned but not yet executed.[/yellow]"
-                )
-                console.print(
-                    f"Run [cyan]zerg rush[/cyan] to start,"
-                    f" or [cyan]zerg cleanup -f {feature}[/cyan] to remove."
-                )
+                task_graph_path = spec_dir / "task-graph.json"
+                started = spec_dir / ".started"
+                if task_graph_path.exists():
+                    console.print(
+                        f"[yellow]Feature '{feature}' is designed but not yet executing.[/yellow]"
+                    )
+                    try:
+                        tg = json.loads(task_graph_path.read_text())
+                        total = tg.get("total_tasks", "?")
+                        levels = tg.get("levels", {})
+                        max_par = tg.get("max_parallelization", "?")
+                        console.print(f"\n[bold]Task Graph Summary[/bold]")
+                        console.print(f"  Tasks: {total}  |  Levels: {len(levels)}  |  Max parallel: {max_par}")
+                        for lvl_num, lvl_data in sorted(levels.items(), key=lambda x: int(x[0])):
+                            name = lvl_data.get("name", "")
+                            task_ids = lvl_data.get("tasks", [])
+                            console.print(f"  L{lvl_num} ({name}): {len(task_ids)} tasks")
+                    except Exception:
+                        pass
+                    console.print(
+                        f"\nRun [cyan]zerg rush[/cyan] to start execution,"
+                        f" or [cyan]zerg cleanup -f {feature}[/cyan] to remove."
+                    )
+                elif started.exists():
+                    console.print(
+                        f"[yellow]Feature '{feature}' design is in progress.[/yellow]"
+                    )
+                else:
+                    console.print(
+                        f"[yellow]Feature '{feature}' is planned but not yet designed.[/yellow]"
+                    )
+                    console.print(
+                        f"Run [cyan]zerg design[/cyan] to create task graph,"
+                        f" or [cyan]zerg cleanup -f {feature}[/cyan] to remove."
+                    )
             else:
                 console.print(
                     f"[red]Error:[/red] No state found for feature '{feature}'"


### PR DESCRIPTION
## Summary
- `zerg status` now distinguishes three pre-execution stages instead of a single generic message:
  - **Planned** (spec dir only): "planned but not yet designed" — suggests `zerg design`
  - **Design in progress** (`.started` exists): "design is in progress"
  - **Designed** (`task-graph.json` exists): "designed but not yet executing" — shows task graph summary (tasks, levels, max parallelism) and suggests `zerg rush`
- Updated existing test assertion to match the refined messaging

## Test plan
- [x] `python -m zerg status` on `brainstorm-command` (designed, no state) now shows task graph summary
- [x] All 82 status tests pass (`pytest tests/unit/test_status_cmd.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)