### PR TITLE
docs: update documentation for 11-action /zerg:git command

### DIFF
--- a/.zerg/wiki/Command-Reference.md
+++ b/.zerg/wiki/Command-Reference.md
@@ -33,7 +33,7 @@ During execution, use `stop` to halt workers, `retry` to re-run failed tasks, an
 | [[/zerg:review|Command-review]] | Two-stage code review (spec compliance + quality) | Quality |
 | [[/zerg:security|Command-security]] | Vulnerability scanning and secure coding rules | Quality |
 | [[/zerg:refactor|Command-refactor]] | Automated code improvement and cleanup | Quality |
-| [[/zerg:git|Command-git]] | Intelligent commits, branch management, finish workflow | Utility |
+| [[/zerg:git|Command-git]] | Git operations: commits, PRs, releases, rescue, review, bisect | Utility |
 | [[/zerg:debug|Command-debug]] | Deep diagnostic investigation with Bayesian hypothesis testing | Utility |
 | [[/zerg:worker|Command-worker]] | Internal: zergling execution protocol | Utility |
 | [[/zerg:plugins|Command-plugins]] | Plugin system management | Utility |
@@ -82,7 +82,7 @@ During execution, use `stop` to halt workers, `retry` to re-run failed tasks, an
 
 ### Utilities
 
-- **[[/zerg:git|Command-git]]** -- Intelligent git operations: commit, branch, merge, sync, history, and finish workflows.
+- **[[/zerg:git|Command-git]]** -- Git operations: commit, branch, merge, sync, history, finish, pr, release, review, rescue, bisect.
 - **[[/zerg:debug|Command-debug]]** -- Deep diagnostic investigation with Bayesian hypothesis testing and recovery plans.
 - **[[/zerg:worker|Command-worker]]** -- Internal zergling execution protocol. Not invoked directly by users.
 - **[[/zerg:plugins|Command-plugins]]** -- Plugin system management: quality gates, lifecycle hooks, and custom launchers.

--- a/.zerg/wiki/Command-git.md
+++ b/.zerg/wiki/Command-git.md
@@ -1,49 +1,55 @@
 # /zerg:git
 
-Git operations with intelligent commit messages and a structured finish workflow.
+Git operations with intelligent commits, PR creation, releases, rescue, review, and bisect.
 
 ## Synopsis
 
 ```
-/zerg:git --action commit|branch|merge|sync|history|finish
+/zerg:git --action commit|branch|merge|sync|history|finish|pr|release|review|rescue|bisect
           [--push]
           [--base main]
+          [--mode auto|confirm|suggest]
+          [--draft] [--reviewer USER]
+          [--bump auto|major|minor|patch] [--dry-run]
+          [--focus security|performance|quality|architecture]
+          [--symptom TEXT] [--test-cmd CMD] [--good REF]
+          [--list-ops] [--undo] [--restore TAG] [--recover-branch NAME]
 ```
 
 ## Description
 
-The `git` command wraps common Git operations with ZERG-aware intelligence. It auto-generates conventional commit messages from staged changes, manages branches, performs merges with conflict detection, and provides a structured finish workflow for completing development branches.
+The `git` command wraps common Git operations with ZERG-aware intelligence. It auto-generates conventional commit messages from staged changes, manages branches, performs merges with conflict detection, provides a structured finish workflow, creates pull requests with full context assembly, automates semver releases, assembles pre-review context filtered by security rules, offers triple-layer undo/recovery, and runs AI-powered bug bisection.
 
 ### Actions
 
-**commit** -- Stage and commit changes with an auto-generated conventional commit message. Optionally push to the remote.
+**commit** -- Stage and commit changes with an auto-generated conventional commit message. Supports multiple modes for different workflows. Optionally push to the remote.
 
 ```
-/zerg:git --action commit [--push]
+/zerg:git --action commit [--push] [--mode auto|confirm|suggest]
 ```
 
-**branch** -- Create and switch to a new branch.
+**branch** -- Create and switch to a new branch, or list existing branches.
 
 ```
-/zerg:git --action branch --name feature/auth
+/zerg:git --action branch --name feature/auth [--base main]
 ```
 
-**merge** -- Merge a branch with intelligent conflict detection.
+**merge** -- Merge a branch with intelligent conflict detection and configurable strategy.
 
 ```
 /zerg:git --action merge --branch feature/auth --strategy squash
 ```
 
-**sync** -- Synchronize the local branch with its remote tracking branch.
+**sync** -- Synchronize the local branch with its remote tracking branch. Fetches, pulls with rebase, and optionally rebases onto the base branch.
 
 ```
-/zerg:git --action sync
+/zerg:git --action sync [--base main]
 ```
 
-**history** -- Analyze commit history and generate a changelog from a given starting point.
+**history** -- Analyze commit history and generate a changelog from a given starting point. Optionally run history cleanup.
 
 ```
-/zerg:git --action history --since v1.0.0
+/zerg:git --action history --since v1.0.0 [--cleanup] [--base main]
 ```
 
 **finish** -- Complete a development branch with a structured set of options. This action presents an interactive menu:
@@ -57,6 +63,39 @@ Implementation complete. All tests passing. What would you like to do?
 4. Discard this work
 
 Which option?
+```
+
+**pr** -- Create a pull request with full context assembly. The PREngine gathers commits, linked issues, and project spec files to generate a structured PR title, body, labels, and reviewers. Supports draft PRs and reviewer assignment.
+
+```
+/zerg:git --action pr --base main [--draft] [--reviewer octocat]
+```
+
+**release** -- Automated semver release workflow. Calculates the version bump from conventional commits (or accepts a manual override), generates a changelog entry, updates version files, commits, tags, pushes, and creates a GitHub release. Use `--dry-run` to preview without executing.
+
+```
+/zerg:git --action release [--bump auto|major|minor|patch] [--dry-run]
+```
+
+**review** -- Assemble pre-review context for Claude Code AI analysis. Prepares scoped diffs filtered by security rules per file extension and highlights areas matching the chosen focus domain.
+
+```
+/zerg:git --action review --base main [--focus security|performance|quality|architecture]
+```
+
+**rescue** -- Triple-layer undo/recovery system. List recent git operations, undo the last change, restore repository state from snapshot tags, or recover deleted branches from the reflog.
+
+```
+/zerg:git --action rescue --list-ops
+/zerg:git --action rescue --undo
+/zerg:git --action rescue --restore zerg-snapshot-20260201
+/zerg:git --action rescue --recover-branch feature/auth
+```
+
+**bisect** -- AI-powered bug bisection. Ranks commits by likelihood using file overlap and semantic analysis, then runs `git bisect` with test validation to pinpoint the commit that introduced a bug.
+
+```
+/zerg:git --action bisect --symptom "login returns 500" --test-cmd "pytest tests/auth/" [--good v1.2.0]
 ```
 
 ### Conventional Commit Types
@@ -77,13 +116,27 @@ Auto-generated commit messages follow the conventional commits specification:
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--action` | (required) | Git operation to perform. Accepts `commit`, `branch`, `merge`, `sync`, `history`, or `finish`. |
-| `--push` | off | Push to remote after committing or merging. |
-| `--base` | `main` | Base branch for the finish workflow. |
-| `--name` | -- | Branch name for the `branch` action. |
+| `--action`, `-a` | (required) | Git operation to perform. Accepts `commit`, `branch`, `merge`, `sync`, `history`, `finish`, `pr`, `release`, `review`, `rescue`, or `bisect`. |
+| `--push`, `-p` | off | Push to remote after committing, merging, or finishing. |
+| `--base`, `-b` | `main` | Base branch for finish, sync, pr, review, and history workflows. |
+| `--name`, `-n` | -- | Branch name for the `branch` action. |
 | `--branch` | -- | Source branch for the `merge` action. |
-| `--strategy` | -- | Merge strategy (e.g., `squash`) for the `merge` action. |
+| `--strategy` | `squash` | Merge strategy: `merge`, `squash`, or `rebase`. |
 | `--since` | -- | Starting tag or commit for the `history` action. |
+| `--mode` | -- | Commit mode override: `auto`, `confirm`, or `suggest`. |
+| `--cleanup` | off | Run history cleanup (for `history` action). |
+| `--draft` | off | Create a draft pull request (for `pr` action). |
+| `--reviewer` | -- | GitHub username to assign as PR reviewer (for `pr` action). |
+| `--focus` | -- | Focus domain for the `review` action: `security`, `performance`, `quality`, or `architecture`. |
+| `--bump` | `auto` | Version bump type for `release`: `auto`, `major`, `minor`, or `patch`. |
+| `--dry-run` | off | Preview the release without executing (for `release` action). |
+| `--symptom` | -- | Bug symptom description (for `bisect` action). |
+| `--test-cmd` | -- | Test command to validate each bisect step (for `bisect` action). |
+| `--good` | -- | Known good commit or tag (for `bisect` action). |
+| `--list-ops` | off | List recent git operations with timestamps (for `rescue` action). |
+| `--undo` | off | Undo the last recorded operation (for `rescue` action). |
+| `--restore` | -- | Restore repository state from a snapshot tag (for `rescue` action). |
+| `--recover-branch` | -- | Recover a deleted branch from the reflog (for `rescue` action). |
 
 ## Examples
 
@@ -99,10 +152,28 @@ Commit and push in one step:
 /zerg:git --action commit --push
 ```
 
+Auto-commit without confirmation:
+
+```
+/zerg:git --action commit --mode auto --push
+```
+
+Preview a suggested commit message without committing:
+
+```
+/zerg:git --action commit --mode suggest
+```
+
 Create a new feature branch:
 
 ```
 /zerg:git --action branch --name feature/auth
+```
+
+Squash merge a feature branch:
+
+```
+/zerg:git --action merge --branch feature/auth --strategy squash
 ```
 
 Complete the current branch with the finish workflow:
@@ -115,6 +186,90 @@ Generate a changelog since v1.0.0:
 
 ```
 /zerg:git --action history --since v1.0.0
+```
+
+Run history cleanup:
+
+```
+/zerg:git --action history --cleanup --base main
+```
+
+Create a pull request against main:
+
+```
+/zerg:git --action pr --base main
+```
+
+Create a draft PR with a reviewer:
+
+```
+/zerg:git --action pr --draft --reviewer octocat
+```
+
+Auto-detect version bump and release:
+
+```
+/zerg:git --action release
+```
+
+Force a minor release:
+
+```
+/zerg:git --action release --bump minor
+```
+
+Preview a release without executing:
+
+```
+/zerg:git --action release --dry-run
+```
+
+Generate a security-focused review context:
+
+```
+/zerg:git --action review --focus security
+```
+
+Generate an architecture review against develop:
+
+```
+/zerg:git --action review --focus architecture --base develop
+```
+
+List recent rescue operations:
+
+```
+/zerg:git --action rescue --list-ops
+```
+
+Undo the last git operation:
+
+```
+/zerg:git --action rescue --undo
+```
+
+Restore from a snapshot tag:
+
+```
+/zerg:git --action rescue --restore zerg-snapshot-20260201
+```
+
+Recover a deleted branch:
+
+```
+/zerg:git --action rescue --recover-branch feature/auth
+```
+
+Bisect with a symptom and test command:
+
+```
+/zerg:git --action bisect --symptom "login returns 500" --test-cmd "pytest tests/auth/"
+```
+
+Bisect with a known good tag:
+
+```
+/zerg:git --action bisect --symptom "CSS broken" --good v1.2.0
 ```
 
 ## Exit Codes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 8 new feature issues for open-source release roadmap
 - GitHub Actions workflow to enforce CHANGELOG.md updates on PRs (skippable with `skip-changelog` label)
 - Claude Code instruction in CLAUDE.md to proactively update changelog when creating PRs
+- Updated README, `docs/commands.md`, wiki `Command-git.md`, and `Command-Reference.md` to document all 11 `/zerg:git` actions
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ ZERG provides 26 slash commands organized into five categories. See the [Command
 
 | Command | Purpose |
 |---------|---------|
-| `/zerg:git` | Intelligent commits, branch management, finish workflow |
+| `/zerg:git` | Git operations: commits, PRs, releases, rescue, review, bisect (11 actions) |
 | `/zerg:debug` | Deep diagnostic investigation with Bayesian hypothesis testing |
 | `/zerg:worker` | Internal: zergling execution protocol |
 | `/zerg:plugins` | Plugin system management |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1030,33 +1030,59 @@ Automated code improvement and cleanup.
 
 ### /zerg:git
 
-Git operations with intelligent commits and finish workflow.
+Git operations with intelligent commits, PR creation, releases, rescue, review, and bisect.
 
-**When to use**: For commit, branch, merge, sync, history, or to finish a development branch.
+**When to use**: For commit, branch, merge, sync, history, finish, PR creation, releases, code review, rescue/undo operations, or AI-powered bug bisection.
 
 #### Usage
 
 ```bash
 /zerg:git --action commit            # Intelligent commit message
 /zerg:git --action commit --push     # Commit and push
+/zerg:git --action commit --mode suggest  # Suggest message without committing
 /zerg:git --action branch --name feature/auth
 /zerg:git --action merge --branch feature/auth --strategy squash
 /zerg:git --action sync              # Synchronize with remote
 /zerg:git --action history --since v1.0.0
+/zerg:git --action history --cleanup # Clean up commit history
 /zerg:git --action finish            # Complete development branch
+/zerg:git --action pr --draft        # Create a draft pull request
+/zerg:git --action pr --reviewer octocat  # Create PR with reviewer
+/zerg:git --action release --bump minor   # Minor version release
+/zerg:git --action release --dry-run      # Preview release without executing
+/zerg:git --action review --focus security  # Pre-review with security focus
+/zerg:git --action rescue --list-ops       # List rescue operations
+/zerg:git --action rescue --undo           # Undo last operation
+/zerg:git --action rescue --restore v1.2.0 # Restore snapshot tag
+/zerg:git --action rescue --recover-branch feature/lost  # Recover deleted branch
+/zerg:git --action bisect --symptom "login returns 500" --test-cmd "pytest tests/auth" --good v1.0.0
 ```
 
 #### Flags
 
 | Flag | Description |
 |------|-------------|
-| `--action TEXT` | Action: `commit`, `branch`, `merge`, `sync`, `history`, `finish` |
-| `--push` | Push after commit |
-| `--base TEXT` | Base branch for merge/finish (default: `main`) |
-| `--name TEXT` | Branch name (for branch action) |
+| `--action, -a TEXT` | Action: `commit`, `branch`, `merge`, `sync`, `history`, `finish`, `pr`, `release`, `review`, `rescue`, `bisect` |
+| `--push, -p` | Push after commit/finish |
+| `--base, -b TEXT` | Base branch (default: `main`) |
+| `--name, -n TEXT` | Branch name (for branch action) |
 | `--branch TEXT` | Branch to merge (for merge action) |
-| `--strategy TEXT` | Merge strategy (for merge action) |
+| `--strategy TEXT` | Merge strategy: `merge`, `squash`, `rebase` (default: `squash`) |
 | `--since TEXT` | Starting point for history |
+| `--mode TEXT` | Commit mode: `auto`, `confirm`, `suggest` |
+| `--cleanup` | Run history cleanup (for history action) |
+| `--draft` | Create draft PR (for pr action) |
+| `--reviewer TEXT` | PR reviewer username (for pr action) |
+| `--focus TEXT` | Review focus: `security`, `performance`, `quality`, `architecture` |
+| `--bump TEXT` | Release bump type: `auto`, `major`, `minor`, `patch` (default: `auto`) |
+| `--dry-run` | Preview release without executing (for release action) |
+| `--symptom TEXT` | Bug symptom description (for bisect action) |
+| `--test-cmd TEXT` | Test command for bisect verification |
+| `--good TEXT` | Known good commit or tag (for bisect action) |
+| `--list-ops` | List rescue operations (for rescue action) |
+| `--undo` | Undo last operation (for rescue action) |
+| `--restore TEXT` | Restore snapshot tag (for rescue action) |
+| `--recover-branch TEXT` | Recover deleted branch (for rescue action) |
 
 #### Finish Workflow
 
@@ -1066,6 +1092,46 @@ The `finish` action presents four options after verifying tests pass:
 2. **Push and create a Pull Request**
 3. **Keep the branch as-is** (handle it later)
 4. **Discard this work**
+
+#### PR Creation
+
+The `pr` action creates a pull request with full context:
+
+1. Analyzes all commits on the current branch vs base
+2. Generates a descriptive title and body with summary and test plan
+3. Supports `--draft` for work-in-progress PRs and `--reviewer` to request reviews
+
+#### Release Workflow
+
+The `release` action performs a semver release:
+
+1. Determines next version from conventional commit history (`--bump auto` analyzes commits)
+2. Updates CHANGELOG.md and version files
+3. Creates a git tag and pushes (unless `--dry-run` is specified)
+
+#### Rescue Operations
+
+The `rescue` action provides undo and recovery:
+
+- `--list-ops` — Show recent operations that can be undone
+- `--undo` — Undo the last git operation
+- `--restore TAG` — Restore a previously saved snapshot tag
+- `--recover-branch NAME` — Recover a deleted branch from reflog
+
+#### Review
+
+The `review` action assembles pre-review context for the current branch:
+
+1. Collects diff, commit history, and changed file summaries
+2. Optionally focuses analysis on a domain with `--focus` (security, performance, quality, architecture)
+
+#### Bisect
+
+The `bisect` action performs AI-powered bug bisection:
+
+1. Requires `--symptom` (description of the bug), `--test-cmd` (verification command), and `--good` (known working ref)
+2. Automates `git bisect` using the test command to identify the first bad commit
+3. Reports the offending commit with context about what changed
 
 #### Conventional Commits
 


### PR DESCRIPTION
## Summary
- Updated README.md, docs/commands.md, wiki Command-git.md, and Command-Reference.md to document all 11 `/zerg:git` actions
- Added documentation for 5 new actions: `pr`, `release`, `review`, `rescue`, `bisect`
- Expanded flags table from 7 to 21 flags with descriptions
- Added usage examples and workflow sections for each new action

## Test plan
- [x] Verify `grep -q bisect` in all 4 updated files
- [x] Verify CHANGELOG.md entry added under `[Unreleased] ### Changed`
- [ ] Visual review of rendered markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)