### PR TITLE
feat: add ship action to /zerg:git

### DIFF
--- a/.zerg/wiki/Command-Reference.md
+++ b/.zerg/wiki/Command-Reference.md
@@ -33,7 +33,7 @@ During execution, use `stop` to halt workers, `retry` to re-run failed tasks, an
 | [[/zerg:review|Command-review]] | Two-stage code review (spec compliance + quality) | Quality |
 | [[/zerg:security|Command-security]] | Vulnerability scanning and secure coding rules | Quality |
 | [[/zerg:refactor|Command-refactor]] | Automated code improvement and cleanup | Quality |
-| [[/zerg:git|Command-git]] | Git operations: commits, PRs, releases, rescue, review, bisect | Utility |
+| [[/zerg:git|Command-git]] | Git operations: commits, PRs, releases, rescue, review, bisect, ship (12 actions) | Utility |
 | [[/zerg:debug|Command-debug]] | Deep diagnostic investigation with Bayesian hypothesis testing | Utility |
 | [[/zerg:worker|Command-worker]] | Internal: zergling execution protocol | Utility |
 | [[/zerg:plugins|Command-plugins]] | Plugin system management | Utility |
@@ -82,7 +82,7 @@ During execution, use `stop` to halt workers, `retry` to re-run failed tasks, an
 
 ### Utilities
 
-- **[[/zerg:git|Command-git]]** -- Git operations: commit, branch, merge, sync, history, finish, pr, release, review, rescue, bisect.
+- **[[/zerg:git|Command-git]]** -- Git operations: commit, branch, merge, sync, history, finish, pr, release, review, rescue, bisect, ship.
 - **[[/zerg:debug|Command-debug]]** -- Deep diagnostic investigation with Bayesian hypothesis testing and recovery plans.
 - **[[/zerg:worker|Command-worker]]** -- Internal zergling execution protocol. Not invoked directly by users.
 - **[[/zerg:plugins|Command-plugins]]** -- Plugin system management: quality gates, lifecycle hooks, and custom launchers.

--- a/.zerg/wiki/Command-git.md
+++ b/.zerg/wiki/Command-git.md
@@ -1,11 +1,11 @@
 # /zerg:git
 
-Git operations with intelligent commits, PR creation, releases, rescue, review, and bisect.
+Git operations with intelligent commits, PR creation, releases, rescue, review, bisect, and ship.
 
 ## Synopsis
 
 ```
-/zerg:git --action commit|branch|merge|sync|history|finish|pr|release|review|rescue|bisect
+/zerg:git --action commit|branch|merge|sync|history|finish|pr|release|review|rescue|bisect|ship
           [--push]
           [--base main]
           [--mode auto|confirm|suggest]
@@ -14,6 +14,7 @@ Git operations with intelligent commits, PR creation, releases, rescue, review, 
           [--focus security|performance|quality|architecture]
           [--symptom TEXT] [--test-cmd CMD] [--good REF]
           [--list-ops] [--undo] [--restore TAG] [--recover-branch NAME]
+          [--no-merge]
 ```
 
 ## Description
@@ -98,6 +99,12 @@ Which option?
 /zerg:git --action bisect --symptom "login returns 500" --test-cmd "pytest tests/auth/" [--good v1.2.0]
 ```
 
+**ship** -- Full delivery pipeline: commit, push, create PR, merge, and cleanup in one shot. Non-interactive. Uses auto mode for commit generation. Tries regular merge first, falls back to admin merge if blocked by branch protection.
+
+```
+/zerg:git --action ship [--base main] [--draft] [--reviewer USER] [--no-merge]
+```
+
 ### Conventional Commit Types
 
 Auto-generated commit messages follow the conventional commits specification:
@@ -116,7 +123,7 @@ Auto-generated commit messages follow the conventional commits specification:
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--action`, `-a` | (required) | Git operation to perform. Accepts `commit`, `branch`, `merge`, `sync`, `history`, `finish`, `pr`, `release`, `review`, `rescue`, or `bisect`. |
+| `--action`, `-a` | (required) | Git operation to perform. Accepts `commit`, `branch`, `merge`, `sync`, `history`, `finish`, `pr`, `release`, `review`, `rescue`, `bisect`, or `ship`. |
 | `--push`, `-p` | off | Push to remote after committing, merging, or finishing. |
 | `--base`, `-b` | `main` | Base branch for finish, sync, pr, review, and history workflows. |
 | `--name`, `-n` | -- | Branch name for the `branch` action. |
@@ -137,6 +144,7 @@ Auto-generated commit messages follow the conventional commits specification:
 | `--undo` | off | Undo the last recorded operation (for `rescue` action). |
 | `--restore` | -- | Restore repository state from a snapshot tag (for `rescue` action). |
 | `--recover-branch` | -- | Recover a deleted branch from the reflog (for `rescue` action). |
+| `--no-merge` | off | Stop after PR creation, skip merge and cleanup (for `ship` action). |
 
 ## Examples
 
@@ -270,6 +278,18 @@ Bisect with a known good tag:
 
 ```
 /zerg:git --action bisect --symptom "CSS broken" --good v1.2.0
+```
+
+Ship current branch (full pipeline):
+
+```
+/zerg:git --action ship
+```
+
+Ship with draft PR for team review:
+
+```
+/zerg:git --action ship --no-merge --draft --reviewer octocat
 ```
 
 ## Exit Codes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 5 new CLI actions: `pr`, `release`, `review`, `rescue`, `bisect` (total: 11 actions)
 - `git.core.md` and `git.details.md` command file split for context engineering
 - 402 new tests across 12 test files for the git package
+- `ship` action for `/zerg:git`: full delivery pipeline (commit → push → PR → merge → cleanup) with `--no-merge` flag
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ ZERG provides 26 slash commands organized into five categories. See the [Command
 
 | Command | Purpose |
 |---------|---------|
-| `/zerg:git` | Git operations: commits, PRs, releases, rescue, review, bisect (11 actions) |
+| `/zerg:git` | Git operations: commits, PRs, releases, rescue, review, bisect, ship (12 actions) |
 | `/zerg:debug` | Deep diagnostic investigation with Bayesian hypothesis testing |
 | `/zerg:worker` | Internal: zergling execution protocol |
 | `/zerg:plugins` | Plugin system management |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1056,13 +1056,14 @@ Git operations with intelligent commits, PR creation, releases, rescue, review, 
 /zerg:git --action rescue --restore v1.2.0 # Restore snapshot tag
 /zerg:git --action rescue --recover-branch feature/lost  # Recover deleted branch
 /zerg:git --action bisect --symptom "login returns 500" --test-cmd "pytest tests/auth" --good v1.0.0
+/zerg:git --action ship              # Full pipeline: commit, push, PR, merge, cleanup
 ```
 
 #### Flags
 
 | Flag | Description |
 |------|-------------|
-| `--action, -a TEXT` | Action: `commit`, `branch`, `merge`, `sync`, `history`, `finish`, `pr`, `release`, `review`, `rescue`, `bisect` |
+| `--action, -a TEXT` | Action: `commit`, `branch`, `merge`, `sync`, `history`, `finish`, `pr`, `release`, `review`, `rescue`, `bisect`, `ship` |
 | `--push, -p` | Push after commit/finish |
 | `--base, -b TEXT` | Base branch (default: `main`) |
 | `--name, -n TEXT` | Branch name (for branch action) |
@@ -1083,6 +1084,7 @@ Git operations with intelligent commits, PR creation, releases, rescue, review, 
 | `--undo` | Undo last operation (for rescue action) |
 | `--restore TEXT` | Restore snapshot tag (for rescue action) |
 | `--recover-branch TEXT` | Recover deleted branch (for rescue action) |
+| `--no-merge` | Stop after PR creation (skip merge+cleanup, for ship action) |
 
 #### Finish Workflow
 
@@ -1132,6 +1134,18 @@ The `bisect` action performs AI-powered bug bisection:
 1. Requires `--symptom` (description of the bug), `--test-cmd` (verification command), and `--good` (known working ref)
 2. Automates `git bisect` using the test command to identify the first bad commit
 3. Reports the offending commit with context about what changed
+
+#### Ship
+
+The `ship` action executes the full delivery pipeline in one shot:
+
+1. **Commit** — Auto-generate conventional commit message and commit
+2. **Push** — Push branch to remote
+3. **Create PR** — Create pull request with full context
+4. **Merge** — Squash merge the PR (falls back to `--admin` if blocked)
+5. **Cleanup** — Switch to base, pull, delete feature branch
+
+Use `--no-merge` to stop after PR creation (for team review workflows).
 
 #### Conventional Commits
 

--- a/zerg/data/commands/git.core.md
+++ b/zerg/data/commands/git.core.md
@@ -5,7 +5,7 @@ Git operations with intelligent commits, PR creation, releases, rescue, review, 
 ## Usage
 
 ```bash
-/zerg:git --action commit|branch|merge|sync|history|finish|pr|release|review|rescue|bisect
+/zerg:git --action commit|branch|merge|sync|history|finish|pr|release|review|rescue|bisect|ship
           [options...]
 ```
 
@@ -24,6 +24,7 @@ Git operations with intelligent commits, PR creation, releases, rescue, review, 
 | review | Pre-review context assembly | --focus |
 | rescue | Undo/recovery operations | --list-ops, --undo, --restore, --recover-branch |
 | bisect | AI-powered bug bisection | --symptom, --test-cmd, --good |
+| ship | Commit, push, PR, merge, cleanup in one shot | --base, --draft, --reviewer, --no-merge |
 
 ## Flags Reference
 
@@ -49,6 +50,7 @@ Git operations with intelligent commits, PR creation, releases, rescue, review, 
 --undo                 Undo last operation (rescue)
 --restore TAG          Restore snapshot tag (rescue)
 --recover-branch NAME  Recover deleted branch (rescue)
+--no-merge             Stop after PR creation (skip merge+cleanup)
 ```
 
 ## Task Tracking

--- a/zerg/data/commands/git.details.md
+++ b/zerg/data/commands/git.details.md
@@ -1,6 +1,6 @@
 # ZERG Git (Details)
 
-Detailed reference for all 11 git actions, their workflows, and advanced usage.
+Detailed reference for all 12 git actions, their workflows, and advanced usage.
 
 ## Action: commit
 
@@ -295,6 +295,38 @@ AI-powered binary search for bug-introducing commits via BisectEngine.
 # Bisect with all options
 /zerg:git --action bisect --symptom "memory leak" --test-cmd "python bench.py" --good abc123 --base main
 ```
+
+---
+
+## Action: ship
+
+**Full delivery pipeline**: commit → push → create PR → merge PR → cleanup branch.
+
+Non-interactive by default. Uses `mode=auto` for commit generation.
+
+```bash
+# Ship current branch to main
+/zerg:git --action ship
+
+# Ship with draft PR and reviewer
+/zerg:git --action ship --draft --reviewer octocat
+
+# Ship but stop after PR creation (for team review)
+/zerg:git --action ship --no-merge
+
+# Ship to a different base branch
+/zerg:git --action ship --base develop
+```
+
+**Pipeline steps:**
+
+1. **Commit** — Stage all changes, auto-generate conventional commit message, commit
+2. **Push** — Push branch to remote with `--set-upstream`
+3. **Create PR** — Create pull request via `gh pr create` with full context
+4. **Merge** — Merge PR via `gh pr merge --squash` (falls back to `--admin` if blocked)
+5. **Cleanup** — Switch to base, pull latest, delete feature branch (local + remote)
+
+If `--no-merge` is set, stops after step 3. If any step fails, the pipeline stops and reports the failure point.
 
 ---
 

--- a/zerg/data/commands/git.md
+++ b/zerg/data/commands/git.md
@@ -5,7 +5,7 @@ Git operations with intelligent commits, PR creation, releases, rescue, review, 
 ## Usage
 
 ```bash
-/zerg:git --action commit|branch|merge|sync|history|finish|pr|release|review|rescue|bisect
+/zerg:git --action commit|branch|merge|sync|history|finish|pr|release|review|rescue|bisect|ship
           [options...]
 ```
 
@@ -24,6 +24,7 @@ Git operations with intelligent commits, PR creation, releases, rescue, review, 
 | review | Pre-review context assembly | --focus |
 | rescue | Undo/recovery operations | --list-ops, --undo, --restore, --recover-branch |
 | bisect | AI-powered bug bisection | --symptom, --test-cmd, --good |
+| ship | Commit, push, PR, merge, cleanup in one shot | --base, --draft, --reviewer, --no-merge |
 
 ## Flags Reference
 
@@ -49,6 +50,7 @@ Git operations with intelligent commits, PR creation, releases, rescue, review, 
 --undo                 Undo last operation (rescue)
 --restore TAG          Restore snapshot tag (rescue)
 --recover-branch NAME  Recover deleted branch (rescue)
+--no-merge             Stop after PR creation (skip merge+cleanup)
 ```
 
 ## Conventional Commits
@@ -92,7 +94,7 @@ When `--help` is passed in `$ARGUMENTS`, display usage and exit:
 /zerg:git -- Git operations with intelligent commits, PR creation, releases, and more.
 
 Flags:
-  --action commit|branch|merge|sync|history|finish|pr|release|review|rescue|bisect
+  --action commit|branch|merge|sync|history|finish|pr|release|review|rescue|bisect|ship
                     Git action to perform (required)
   --push            Push after operation
   --base main       Base branch (default: main)
@@ -116,5 +118,6 @@ Flags:
   --restore TAG     Restore snapshot (rescue)
   --recover-branch NAME
                     Recover branch (rescue)
+  --no-merge        Stop after PR creation (skip merge+cleanup)
   --help            Show this help message
 ```


### PR DESCRIPTION
## Summary
- Adds `ship` as the 12th `/zerg:git` action: chains commit → push → PR → merge → cleanup in one non-interactive command
- Adds `--no-merge` flag to stop after PR creation for team review workflows
- Tries regular merge first, falls back to admin merge if blocked by branch protection

## Changes
- `zerg/commands/git_cmd.py`: `action_ship()` function (~60 lines), `--no-merge` Click option, dispatch case
- `tests/unit/test_git_cmd.py`: 7 new tests (happy path, failures, admin fallback, no-merge, no-changes)
- Spec files: `git.core.md`, `git.details.md`, `git.md` updated with ship action + --no-merge
- Docs: README, commands.md, wiki Command-git.md, Command-Reference.md, CHANGELOG.md

## Test plan
- [x] `pytest tests/unit/test_git_cmd.py -x -v -k ship` — 7/7 passing
- [x] All 101 git tests passing
- [x] `grep -q 'ship'` in all spec/doc files

🤖 Generated with [Claude Code](https://claude.com/claude-code)