### PR TITLE
docs: fix --socratic flag documentation to match implementation

### DIFF
--- a/.gsd/.current-brainstorm
+++ b/.gsd/.current-brainstorm
@@ -1,1 +1,1 @@
-brainstorm-66-questioning
+

--- a/.gsd/.current-feature
+++ b/.gsd/.current-feature
@@ -1,1 +1,1 @@
-66-questioning-methodology
+

--- a/.zerg/wiki/Command-brainstorm.md
+++ b/.zerg/wiki/Command-brainstorm.md
@@ -16,11 +16,11 @@ The command follows a multi-phase workflow:
 
 1. **Research** -- Uses WebSearch to analyze competitors, market gaps, and user pain points (3-5 queries). Findings are cached in the session directory.
 
-2. **Socratic Discovery** -- Conducts multiple rounds of structured questions using AskUserQuestion. Operates in two modes:
-   - **Guided mode** (default): Domain-aware question trees drive discovery through problem space, constraints, and solution ideation.
-   - **Open mode** (`--socratic open`): Free-form exploration without domain scaffolding, useful for novel or cross-cutting topics.
+2. **Socratic Discovery** -- Conducts structured questions using AskUserQuestion. Operates in two modes:
+   - **Batch mode** (default): Multiple questions per round, 3 rounds by default (override with `--rounds N`).
+   - **Socratic mode** (`--socratic`): Single-question interactive mode with 6 domain-specific question trees (Auth, API, Data Pipeline, UI/Frontend, Infrastructure, General). Domain is auto-detected from topic keywords.
 
-   Saturation detection automatically stops questioning when 2 consecutive answers introduce no new entities (concepts, constraints, or requirements).
+   Saturation detection automatically stops questioning when 2 consecutive answers introduce no new entities (concepts, constraints, or requirements). Minimum 3 questions before checking.
 
 2.5. **Trade-off Exploration** -- Surfaces competing concerns (e.g., consistency vs. availability, simplicity vs. extensibility) and asks the user to rank or choose between them. Results are captured in `tradeoffs.md`.
 
@@ -64,7 +64,7 @@ The command uses ZERG's context engineering system:
 |--------|-------------|
 | `[domain-or-topic]` | Optional. Domain or topic to brainstorm about |
 | `--rounds N` | Number of Socratic discovery rounds (default: 3, max: 5) |
-| `--socratic [guided\|open]` | Socratic mode. `guided` (default) uses domain question trees; `open` uses free-form exploration |
+| `--socratic` | Enable single-question Socratic mode with domain question trees (default: off, uses batch mode) |
 | `--skip-research` | Skip the web research phase |
 | `--skip-issues` | Ideate only, don't create GitHub issues |
 | `--dry-run` | Preview issues without creating them |
@@ -82,14 +82,11 @@ The command uses ZERG's context engineering system:
 # Extended discovery with 5 rounds, preview only
 /zerg:brainstorm api-improvements --rounds 5 --dry-run
 
-# Use guided Socratic mode with domain-aware question trees
-/zerg:brainstorm authentication --socratic guided
-
-# Use open Socratic mode for free-form exploration
-/zerg:brainstorm "cross-service data flow" --socratic open
+# Use Socratic mode with domain-aware question trees
+/zerg:brainstorm authentication --socratic
 
 # Combine socratic mode with dry-run for pure discovery
-/zerg:brainstorm infrastructure --socratic guided --skip-issues
+/zerg:brainstorm infrastructure --socratic --skip-issues
 ```
 
 ## Output

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -162,9 +162,13 @@ Open-ended feature discovery through competitive research, Socratic questioning,
 
 ```
 .gsd/specs/brainstorm-{timestamp}/
-  research.md     # Competitive analysis findings
-  brainstorm.md   # Session summary with all Q&A
-  issues.json     # Machine-readable issue manifest
+  research.md         # Competitive analysis findings
+  transcript.md       # Full Q&A transcript from discovery
+  tradeoffs.md        # Trade-off decisions and reasoning
+  validated-design.md # User-confirmed scope from Design Validation
+  deferred.md         # Features deferred by YAGNI Gate
+  brainstorm.md       # Session summary with recommendations
+  issues.json         # Machine-readable issue manifest
 ```
 
 #### Context Management


### PR DESCRIPTION
## Summary
- Fix `--socratic` flag documented as `--socratic [guided|open]` with invented sub-modes in wiki `Command-brainstorm.md` — the flag is a simple boolean toggle per `brainstorm.core.md`
- Remove invalid examples using `--socratic guided` and `--socratic open`
- Add 4 missing output files to `docs/commands.md` brainstorm section: `transcript.md`, `tradeoffs.md`, `validated-design.md`, `deferred.md`

## Test plan
- [x] `grep -c 'guided\|open' .zerg/wiki/Command-brainstorm.md` returns 1 (only "open-ended discovery" text, no flag references)
- [x] `--socratic` documented as boolean in options table
- [x] Output file list in docs/commands.md matches brainstorm.core.md phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)