### PR TITLE
feat: wire cross-cutting capabilities from CLI to workers (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Cross-cutting capability wiring: CLI flags now flow through to worker processes via `CapabilityResolver` (#78)
+- `--no-compact` flag (compact output is now ON by default)
+- `--no-loop` flag (improvement loops are now ON by default)
+- `--iterations N` flag to override max loop iterations
+- Context plugin capability sections: depth, mode, TDD, and efficiency guidance injected into worker prompts
+- `WorkerContext` capability fields for cross-cutting capability awareness
+- Unit and integration tests for capability resolver and wiring
 - Integration wiring enforcement across the ZERG pipeline (#78, #79, #80, #81):
   - **Module wiring validator** (`validate_module_wiring()` in `validate_commands.py`): Detects orphaned Python modules with zero production imports; allowlists `__init__.py`, `__main__.py`, entry points; `--strict-wiring` CLI flag
   - **CI pytest workflow** (`.github/workflows/pytest.yml`): Runs unit tests, integration tests, and `validate_commands` on every PR
@@ -51,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `--uc`/`--compact` deprecated (compact is now default behavior)
+- `--loop` deprecated (loops are now default behavior)
+- Context plugin budget rebalanced: rules 10%, security 10%, spec 25%, MCP 10%, depth 10%, mode 10%, TDD 10%, efficiency 5%, buffer 10%
 - `zerg/git_ops.py` converted to backward-compatible shim re-exporting from `zerg/git/ops.py`
 - `zerg/commands/git_cmd.py` expanded from 6 to 11 actions with engine delegation
 - Context engineering guardrails: automated drift detection and command validation (`python -m zerg.validate_commands`)
@@ -61,6 +71,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions workflow to enforce CHANGELOG.md updates on PRs (skippable with `skip-changelog` label)
 - Claude Code instruction in CLAUDE.md to proactively update changelog when creating PRs
 - Updated README, `docs/commands.md`, wiki `Command-git.md`, and `Command-Reference.md` to document all 11 `/zerg:git` actions
+
+### Deprecated
+
+- `--uc`, `--compact` flags (use `--no-compact` to disable instead)
+- `--loop` flag (use `--no-loop` to disable instead)
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,11 +168,11 @@ ZERG includes 8 cross-cutting capabilities controlled via CLI flags and config:
 | Capability | CLI Flag | Config Section |
 |------------|----------|---------------|
 | Analysis Depth Tiers | `--quick/--think/--think-hard/--ultrathink` | — |
-| Token Efficiency | `--uc/--compact` | `efficiency` |
+| Token Efficiency | `--no-compact` (ON by default) | `efficiency` |
 | Behavioral Modes | `--mode` | `behavioral_modes` |
 | MCP Auto-Routing | `--mcp/--no-mcp` | `mcp_routing` |
 | Engineering Rules | — | `rules` |
-| Improvement Loops | `--loop/--iterations` | `improvement_loops` |
+| Improvement Loops | `--no-loop/--iterations` (ON by default) | `improvement_loops` |
 | Verification Gates | — | `verification` |
 | TDD Enforcement | `--tdd` | `tdd` |
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -61,9 +61,11 @@ Mutually exclusive flags controlling analysis depth:
 
 ### Output & Efficiency
 
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--uc` | `--compact` | Ultra-compressed token-efficient output |
+| Flag | Description |
+|------|-------------|
+| `--no-compact` | Disable compact output (compact is ON by default) |
+
+> **Note**: `--uc` and `--compact` are deprecated. Compact output is now enabled by default. Use `--no-compact` to disable it.
 
 ### Behavioral Mode
 
@@ -77,6 +79,15 @@ Mutually exclusive flags controlling analysis depth:
 |------|-------------|
 | `--mcp` | Enable MCP auto-routing (default) |
 | `--no-mcp` | Disable all MCP server recommendations |
+
+### Improvement Loops
+
+| Flag | Description |
+|------|-------------|
+| `--no-loop` | Disable improvement loops (loops are ON by default) |
+| `--iterations N` | Set max loop iterations (overrides config default) |
+
+> **Note**: `--loop` is deprecated. Improvement loops are now enabled by default. Use `--no-loop` to disable them.
 
 ### TDD Enforcement
 

--- a/tests/integration/test_capability_wiring.py
+++ b/tests/integration/test_capability_wiring.py
@@ -1,0 +1,207 @@
+"""Integration tests for capability wiring: rush -> Orchestrator -> WorkerManager -> launcher.
+
+Verifies the full chain from ResolvedCapabilities through Orchestrator construction,
+WorkerManager env injection, and ContextEngineeringPlugin section builders.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from zerg.capability_resolver import ResolvedCapabilities
+from zerg.context_plugin import ContextEngineeringPlugin
+from zerg.plugin_config import ContextEngineeringConfig
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator -> WorkerManager wiring
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorCapabilityWiring:
+    """Verify Orchestrator passes capabilities down to WorkerManager."""
+
+    @pytest.fixture
+    def mock_orchestrator_deps(self):
+        """Mock all Orchestrator dependencies so __init__ completes."""
+        with patch("zerg.orchestrator.StateManager") as state_mock, \
+             patch("zerg.orchestrator.LevelController") as levels_mock, \
+             patch("zerg.orchestrator.TaskParser") as parser_mock, \
+             patch("zerg.orchestrator.GateRunner") as gates_mock, \
+             patch("zerg.orchestrator.WorktreeManager") as worktree_mock, \
+             patch("zerg.orchestrator.ContainerManager") as container_mock, \
+             patch("zerg.orchestrator.PortAllocator") as ports_mock, \
+             patch("zerg.orchestrator.MergeCoordinator") as merge_mock, \
+             patch("zerg.orchestrator.TaskSyncBridge") as task_sync_mock, \
+             patch("zerg.orchestrator.SubprocessLauncher") as subprocess_launcher_mock, \
+             patch("zerg.orchestrator.ContainerLauncher") as container_launcher_mock, \
+             patch("zerg.orchestrator.setup_structured_logging") as log_mock:
+
+            state = MagicMock()
+            state.load.return_value = {}
+            state.get_task_status.return_value = None
+            state.get_task_retry_count.return_value = 0
+            state_mock.return_value = state
+
+            levels = MagicMock()
+            levels.current_level = 1
+            levels_mock.return_value = levels
+
+            parser = MagicMock()
+            parser.get_all_tasks.return_value = []
+            parser.total_tasks = 0
+            parser.levels = [1]
+            parser_mock.return_value = parser
+
+            gates_mock.return_value = MagicMock()
+            worktree_mock.return_value = MagicMock()
+            container_mock.return_value = MagicMock()
+            ports_mock.return_value = MagicMock()
+            merge_mock.return_value = MagicMock()
+            task_sync_mock.return_value = MagicMock()
+            subprocess_launcher_mock.return_value = MagicMock()
+            container_launcher_mock.return_value = MagicMock()
+            log_mock.return_value = MagicMock()
+
+            yield {
+                "state": state,
+                "levels": levels,
+                "parser": parser,
+                "subprocess_launcher": subprocess_launcher_mock,
+            }
+
+    def test_orchestrator_passes_capabilities_to_worker_manager(
+        self, mock_orchestrator_deps
+    ):
+        """Orchestrator(capabilities=...) flows through to _worker_manager._capabilities."""
+        from zerg.orchestrator import Orchestrator
+
+        caps = ResolvedCapabilities(tdd=True, depth_tier="think")
+        orch = Orchestrator(
+            feature="test-feat",
+            repo_path="/tmp",
+            capabilities=caps,
+        )
+        assert orch._worker_manager._capabilities is caps
+        assert orch._worker_manager._capabilities.tdd is True
+        assert orch._worker_manager._capabilities.depth_tier == "think"
+
+
+# ---------------------------------------------------------------------------
+# WorkerManager -> launcher.spawn(env=) wiring
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerManagerSpawnEnv:
+    """Verify WorkerManager.spawn_worker() passes ZERG_* env to launcher.spawn()."""
+
+    def test_worker_manager_spawn_passes_env(self):
+        """spawn_worker() calls launcher.spawn with env= containing ZERG_* vars."""
+        from zerg.worker_manager import WorkerManager
+
+        caps = ResolvedCapabilities(tdd=True, compact=True, depth_tier="think")
+
+        launcher = MagicMock()
+        spawn_result = MagicMock()
+        spawn_result.success = True
+        spawn_result.handle = MagicMock()
+        spawn_result.handle.container_id = None
+        launcher.spawn.return_value = spawn_result
+
+        ports = MagicMock()
+        ports.allocate_one.return_value = 9000
+
+        worktrees = MagicMock()
+        wt_info = MagicMock()
+        wt_info.path = "/tmp/wt"
+        wt_info.branch = "feature-branch"
+        worktrees.create.return_value = wt_info
+
+        state = MagicMock()
+        plugin_registry = MagicMock()
+        plugin_registry.emit.return_value = None
+
+        wm = WorkerManager(
+            feature="test-feat",
+            config=MagicMock(),
+            state=state,
+            levels=MagicMock(),
+            parser=MagicMock(),
+            launcher=launcher,
+            worktrees=worktrees,
+            ports=ports,
+            assigner=None,
+            plugin_registry=plugin_registry,
+            workers={},
+            on_task_complete=[],
+            capabilities=caps,
+        )
+
+        wm.spawn_worker(worker_id=1)
+
+        # Verify launcher.spawn was called with env= containing ZERG_* keys
+        launcher.spawn.assert_called_once()
+        call_kwargs = launcher.spawn.call_args
+        env_arg = call_kwargs.kwargs.get("env") or call_kwargs[1].get("env")
+        assert env_arg is not None, "launcher.spawn was not called with env="
+        assert "ZERG_TDD_MODE" in env_arg
+        assert env_arg["ZERG_TDD_MODE"] == "1"
+        assert "ZERG_COMPACT_MODE" in env_arg
+        assert env_arg["ZERG_COMPACT_MODE"] == "1"
+        assert "ZERG_ANALYSIS_DEPTH" in env_arg
+        assert env_arg["ZERG_ANALYSIS_DEPTH"] == "think"
+
+
+# ---------------------------------------------------------------------------
+# ContextEngineeringPlugin section builders (env var driven)
+# ---------------------------------------------------------------------------
+
+
+class TestContextPluginDepthSection:
+    """Verify _build_depth_section reads ZERG_ANALYSIS_DEPTH env var."""
+
+    def test_depth_section_contains_tier(self, monkeypatch):
+        monkeypatch.setenv("ZERG_ANALYSIS_DEPTH", "think")
+        plugin = ContextEngineeringPlugin(ContextEngineeringConfig())
+        section = plugin._build_depth_section(max_tokens=500)
+        assert "think" in section.lower()
+
+    def test_depth_section_empty_for_standard(self, monkeypatch):
+        monkeypatch.setenv("ZERG_ANALYSIS_DEPTH", "standard")
+        plugin = ContextEngineeringPlugin(ContextEngineeringConfig())
+        section = plugin._build_depth_section(max_tokens=500)
+        assert section == ""
+
+
+class TestContextPluginTddSection:
+    """Verify _build_tdd_section reads ZERG_TDD_MODE env var."""
+
+    def test_tdd_section_contains_red(self, monkeypatch):
+        monkeypatch.setenv("ZERG_TDD_MODE", "1")
+        plugin = ContextEngineeringPlugin(ContextEngineeringConfig())
+        section = plugin._build_tdd_section(max_tokens=500)
+        assert "RED" in section
+
+    def test_tdd_section_empty_when_off(self, monkeypatch):
+        monkeypatch.setenv("ZERG_TDD_MODE", "0")
+        plugin = ContextEngineeringPlugin(ContextEngineeringConfig())
+        section = plugin._build_tdd_section(max_tokens=500)
+        assert section == ""
+
+
+class TestContextPluginEfficiencySection:
+    """Verify _build_efficiency_section reads ZERG_COMPACT_MODE env var."""
+
+    def test_efficiency_section_contains_compact(self, monkeypatch):
+        monkeypatch.setenv("ZERG_COMPACT_MODE", "1")
+        plugin = ContextEngineeringPlugin(ContextEngineeringConfig())
+        section = plugin._build_efficiency_section()
+        assert "Compact" in section
+
+    def test_efficiency_section_empty_when_off(self, monkeypatch):
+        monkeypatch.setenv("ZERG_COMPACT_MODE", "0")
+        plugin = ContextEngineeringPlugin(ContextEngineeringConfig())
+        section = plugin._build_efficiency_section()
+        assert section == ""

--- a/tests/unit/test_capability_resolver.py
+++ b/tests/unit/test_capability_resolver.py
@@ -1,0 +1,187 @@
+"""Unit tests for CapabilityResolver and ResolvedCapabilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from zerg.capability_resolver import CapabilityResolver, ResolvedCapabilities
+from zerg.config import ZergConfig
+
+
+# ---------------------------------------------------------------------------
+# ResolvedCapabilities dataclass tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolvedCapabilitiesDefaults:
+    """Verify ResolvedCapabilities default field values."""
+
+    def test_defaults(self):
+        rc = ResolvedCapabilities()
+        assert rc.compact is True
+        assert rc.loop_enabled is True
+        assert rc.depth_tier == "standard"
+        assert rc.mode == "precision"
+        assert rc.tdd is False
+        assert rc.rules_enabled is True
+        assert rc.gates_enabled is True
+        assert rc.token_budget == 2000
+        assert rc.loop_iterations == 5
+        assert rc.staleness_threshold == 300
+        assert rc.mcp_hint == ""
+
+
+class TestResolvedCapabilitiesToEnvVars:
+    """Verify to_env_vars() key presence, value formatting, and conditional keys."""
+
+    EXPECTED_KEYS = {
+        "ZERG_ANALYSIS_DEPTH",
+        "ZERG_TOKEN_BUDGET",
+        "ZERG_COMPACT_MODE",
+        "ZERG_BEHAVIORAL_MODE",
+        "ZERG_TDD_MODE",
+        "ZERG_RULES_ENABLED",
+        "ZERG_LOOP_ENABLED",
+        "ZERG_LOOP_ITERATIONS",
+        "ZERG_VERIFICATION_GATES",
+        "ZERG_STALENESS_THRESHOLD",
+    }
+
+    def test_to_env_vars_keys(self):
+        """to_env_vars() returns all expected ZERG_* keys (no mcp_hint by default)."""
+        env = ResolvedCapabilities().to_env_vars()
+        assert set(env.keys()) == self.EXPECTED_KEYS
+
+    def test_to_env_vars_values(self):
+        """Boolean fields are stringified as '0'/'1'; int fields as str."""
+        rc = ResolvedCapabilities(
+            compact=True,
+            tdd=False,
+            rules_enabled=True,
+            loop_enabled=False,
+            gates_enabled=True,
+            token_budget=4000,
+            loop_iterations=10,
+            staleness_threshold=600,
+        )
+        env = rc.to_env_vars()
+
+        # Booleans -> "0" / "1"
+        assert env["ZERG_COMPACT_MODE"] == "1"
+        assert env["ZERG_TDD_MODE"] == "0"
+        assert env["ZERG_RULES_ENABLED"] == "1"
+        assert env["ZERG_LOOP_ENABLED"] == "0"
+        assert env["ZERG_VERIFICATION_GATES"] == "1"
+
+        # Ints -> str
+        assert env["ZERG_TOKEN_BUDGET"] == "4000"
+        assert env["ZERG_LOOP_ITERATIONS"] == "10"
+        assert env["ZERG_STALENESS_THRESHOLD"] == "600"
+
+    def test_to_env_vars_mcp_hint_omitted_when_empty(self):
+        """ZERG_MCP_HINT is not present when mcp_hint is empty string."""
+        env = ResolvedCapabilities(mcp_hint="").to_env_vars()
+        assert "ZERG_MCP_HINT" not in env
+
+    def test_to_env_vars_mcp_hint_included(self):
+        """ZERG_MCP_HINT is present when mcp_hint is set."""
+        env = ResolvedCapabilities(mcp_hint="sequential,context7").to_env_vars()
+        assert "ZERG_MCP_HINT" in env
+        assert env["ZERG_MCP_HINT"] == "sequential,context7"
+
+
+# ---------------------------------------------------------------------------
+# CapabilityResolver.resolve() tests
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityResolverResolve:
+    """Verify CapabilityResolver.resolve() with various inputs."""
+
+    @pytest.fixture
+    def resolver(self):
+        return CapabilityResolver()
+
+    @pytest.fixture
+    def default_config(self):
+        return ZergConfig()
+
+    def test_resolve_defaults(self, resolver, default_config):
+        """resolve({}) produces sensible defaults."""
+        rc = resolver.resolve(cli_flags={}, config=default_config)
+        assert isinstance(rc, ResolvedCapabilities)
+        assert rc.depth_tier == "standard"
+        assert rc.compact is True
+        assert rc.tdd is False
+
+    def test_resolve_cli_depth_override(self, resolver, default_config):
+        """CLI depth flag overrides task-graph auto-detection."""
+        rc = resolver.resolve(cli_flags={"depth": "think"}, config=default_config)
+        assert rc.depth_tier == "think"
+        assert rc.token_budget == 4000
+
+    def test_resolve_cli_tdd(self, resolver, default_config):
+        """CLI tdd=True enables TDD mode."""
+        rc = resolver.resolve(cli_flags={"tdd": True}, config=default_config)
+        assert rc.tdd is True
+
+    def test_resolve_compact_off(self, resolver, default_config):
+        """CLI compact=False disables compact mode."""
+        rc = resolver.resolve(cli_flags={"compact": False}, config=default_config)
+        assert rc.compact is False
+
+    def test_resolve_loop_off(self, resolver, default_config):
+        """CLI loop=False disables improvement loops."""
+        rc = resolver.resolve(
+            cli_flags={"loop": False}, config=default_config, command="rush"
+        )
+        assert rc.loop_enabled is False
+
+    def test_resolve_iterations_override(self, resolver, default_config):
+        """CLI iterations value overrides config default."""
+        rc = resolver.resolve(
+            cli_flags={"iterations": 10}, config=default_config
+        )
+        assert rc.loop_iterations == 10
+
+    def test_resolve_deepest_wins_from_task_graph(self, resolver, default_config):
+        """When no CLI depth flag, deepest task tier wins across task graph."""
+        task_graph = {
+            "tasks": [
+                {
+                    "id": "TASK-001",
+                    "description": "simple change",
+                    "files": {"create": ["a.py"]},
+                },
+                {
+                    "id": "TASK-002",
+                    "description": (
+                        "complex architectural refactor spanning security, "
+                        "performance, and database migration layers"
+                    ),
+                    "files": {
+                        "modify": [
+                            f"src/module_{i}.py" for i in range(15)
+                        ]
+                    },
+                },
+            ]
+        }
+        rc = resolver.resolve(
+            cli_flags={},
+            config=default_config,
+            task_graph=task_graph,
+        )
+        # The second task is complex enough that the auto-router should
+        # assign a tier deeper than "standard".  Exact tier depends on
+        # DepthRouter heuristics, so we just verify it is not standard.
+        assert rc.depth_tier != "standard" or rc.token_budget > 2000
+
+    def test_resolve_with_config(self, resolver):
+        """Config values (e.g. rules, verification) are picked up."""
+        config = ZergConfig()
+        rc = resolver.resolve(cli_flags={}, config=config)
+        # ZergConfig defaults should flow through
+        assert rc.rules_enabled == config.rules.enabled
+        assert rc.gates_enabled == config.verification.require_before_completion
+        assert rc.staleness_threshold == config.verification.staleness_threshold_seconds

--- a/zerg/capability_resolver.py
+++ b/zerg/capability_resolver.py
@@ -1,0 +1,229 @@
+"""Cross-cutting capability resolution for ZERG.
+
+Resolves CLI flags, config, and task graph analysis into a unified
+ResolvedCapabilities that gets passed as env vars to workers.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from zerg.config import ZergConfig
+from zerg.depth_tiers import DepthRouter, DepthTier
+from zerg.mcp_router import MCPRouter
+from zerg.modes import BehavioralMode, ModeDetector
+
+logger = logging.getLogger(__name__)
+
+# Commands where loops apply (code-touching commands)
+LOOP_COMMANDS = frozenset({
+    "rush", "refactor", "test", "security", "build", "review", "analyze",
+})
+
+
+@dataclass
+class ResolvedCapabilities:
+    """Resolved cross-cutting capabilities ready for worker injection."""
+
+    # Depth
+    depth_tier: str = "standard"
+    token_budget: int = 2000
+
+    # Compact/efficiency
+    compact: bool = True
+
+    # Behavioral mode
+    mode: str = "precision"
+
+    # MCP routing
+    mcp_hint: str = ""
+
+    # TDD
+    tdd: bool = False
+
+    # Rules
+    rules_enabled: bool = True
+
+    # Loops
+    loop_enabled: bool = True
+    loop_iterations: int = 5
+
+    # Verification gates
+    gates_enabled: bool = True
+    staleness_threshold: int = 300
+
+    def to_env_vars(self) -> dict[str, str]:
+        """Convert to flat ZERG_* env var dict for worker injection."""
+        env: dict[str, str] = {
+            "ZERG_ANALYSIS_DEPTH": self.depth_tier,
+            "ZERG_TOKEN_BUDGET": str(self.token_budget),
+            "ZERG_COMPACT_MODE": "1" if self.compact else "0",
+            "ZERG_BEHAVIORAL_MODE": self.mode,
+            "ZERG_TDD_MODE": "1" if self.tdd else "0",
+            "ZERG_RULES_ENABLED": "1" if self.rules_enabled else "0",
+            "ZERG_LOOP_ENABLED": "1" if self.loop_enabled else "0",
+            "ZERG_LOOP_ITERATIONS": str(self.loop_iterations),
+            "ZERG_VERIFICATION_GATES": "1" if self.gates_enabled else "0",
+            "ZERG_STALENESS_THRESHOLD": str(self.staleness_threshold),
+        }
+        if self.mcp_hint:
+            env["ZERG_MCP_HINT"] = self.mcp_hint
+        return env
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for logging/status output."""
+        return {
+            "depth_tier": self.depth_tier,
+            "token_budget": self.token_budget,
+            "compact": self.compact,
+            "mode": self.mode,
+            "mcp_hint": self.mcp_hint,
+            "tdd": self.tdd,
+            "rules_enabled": self.rules_enabled,
+            "loop_enabled": self.loop_enabled,
+            "loop_iterations": self.loop_iterations,
+            "gates_enabled": self.gates_enabled,
+        }
+
+
+class CapabilityResolver:
+    """Resolves CLI flags + config + task graph into ResolvedCapabilities.
+
+    Design decisions:
+    - Depth: scan all tasks, auto-detect per task via DepthRouter, take max.
+      CLI flag overrides.
+    - Compact/Loop: ON by default for code-touching commands.
+    - Mode: auto-detected from resolved depth, can be CLI-overridden.
+    - MCP: routed based on resolved depth tier.
+    """
+
+    def __init__(self) -> None:
+        self._depth_router = DepthRouter()
+        self._mode_detector = ModeDetector()
+        self._mcp_router = MCPRouter()
+
+    def resolve(
+        self,
+        cli_flags: dict[str, Any],
+        config: ZergConfig,
+        task_graph: dict[str, Any] | None = None,
+        command: str | None = None,
+    ) -> ResolvedCapabilities:
+        """Resolve all capabilities from CLI flags, config, and task graph.
+
+        Args:
+            cli_flags: ctx.obj dict from Click (depth, compact, mode, tdd, etc.)
+            config: ZergConfig instance
+            task_graph: Parsed task-graph.json dict (optional)
+            command: Active command name (e.g. "rush") for loop applicability
+
+        Returns:
+            ResolvedCapabilities ready for worker injection
+        """
+        # --- Depth resolution: deepest wins globally ---
+        depth_tier = self._resolve_depth(cli_flags, task_graph)
+
+        # --- Compact/efficiency ---
+        compact = cli_flags.get("compact", True)
+
+        # --- Behavioral mode ---
+        mode = self._resolve_mode(cli_flags, config, depth_tier)
+
+        # --- MCP routing ---
+        mcp_hint = self._resolve_mcp(config, depth_tier)
+
+        # --- TDD ---
+        tdd = cli_flags.get("tdd", False) or config.tdd.enabled
+
+        # --- Rules ---
+        rules_enabled = config.rules.enabled
+
+        # --- Loops ---
+        is_code_command = command in LOOP_COMMANDS if command else True
+        loop_enabled = cli_flags.get("loop", True) and is_code_command
+        loop_iterations = (
+            cli_flags.get("iterations")
+            or config.improvement_loops.max_iterations
+        )
+
+        # --- Verification gates ---
+        gates_enabled = config.verification.require_before_completion
+        staleness_threshold = config.verification.staleness_threshold_seconds
+
+        resolved = ResolvedCapabilities(
+            depth_tier=depth_tier,
+            token_budget=DepthTier(depth_tier).token_budget,
+            compact=compact,
+            mode=mode,
+            mcp_hint=mcp_hint,
+            tdd=tdd,
+            rules_enabled=rules_enabled,
+            loop_enabled=loop_enabled,
+            loop_iterations=loop_iterations,
+            gates_enabled=gates_enabled,
+            staleness_threshold=staleness_threshold,
+        )
+
+        logger.info("Resolved capabilities: %s", resolved.to_dict())
+        return resolved
+
+    def _resolve_depth(
+        self,
+        cli_flags: dict[str, Any],
+        task_graph: dict[str, Any] | None,
+    ) -> str:
+        """Resolve depth tier. CLI flag overrides, otherwise deepest task wins."""
+        cli_depth = cli_flags.get("depth", "standard")
+        if cli_depth != "standard":
+            # CLI explicitly set a depth flag
+            # Normalize think_hard -> think-hard for DepthTier enum
+            return cli_depth.replace("_", "-")
+
+        if not task_graph:
+            return "standard"
+
+        # Scan all tasks, auto-detect depth per task, take max
+        tasks = task_graph.get("tasks", [])
+        if not tasks:
+            return "standard"
+
+        max_tier = DepthTier.STANDARD
+        for task in tasks:
+            description = task.get("description", "")
+            files = task.get("files", {})
+            file_count = sum(
+                len(v) for v in files.values() if isinstance(v, list)
+            )
+            ctx = self._depth_router.route(
+                description=description,
+                file_count=file_count,
+            )
+            if ctx.tier.token_budget > max_tier.token_budget:
+                max_tier = ctx.tier
+
+        return max_tier.value
+
+    def _resolve_mode(
+        self,
+        cli_flags: dict[str, Any],
+        config: ZergConfig,
+        depth_tier: str,
+    ) -> str:
+        """Resolve behavioral mode."""
+        cli_mode = cli_flags.get("mode")
+        explicit = BehavioralMode(cli_mode) if cli_mode else None
+
+        mode_ctx = self._mode_detector.detect(
+            explicit_mode=explicit,
+            depth_tier=depth_tier,
+        )
+        return mode_ctx.mode.value
+
+    def _resolve_mcp(self, config: ZergConfig, depth_tier: str) -> str:
+        """Resolve MCP server hint from depth tier."""
+        decision = self._mcp_router.route(depth_tier=depth_tier)
+        if decision.recommended_servers:
+            return ",".join(decision.server_names)
+        return ""

--- a/zerg/cli.py
+++ b/zerg/cli.py
@@ -40,10 +40,14 @@ console = Console()
 @click.option("--think", is_flag=True, help="Structured multi-step analysis")
 @click.option("--think-hard", is_flag=True, help="Deep architectural analysis")
 @click.option("--ultrathink", is_flag=True, help="Maximum depth analysis")
-@click.option("--uc", "--compact", "compact", is_flag=True, help="Ultra-compressed token-efficient output")
+@click.option("--no-compact", is_flag=True, default=False, help="Disable compact output (compact is ON by default)")
+@click.option("--uc", "--compact", "compact_legacy", is_flag=True, hidden=True, help="[Deprecated] Compact is now default")
 @click.option("--mode", type=click.Choice(["precision", "speed", "exploration", "refactor", "debug"]), default=None, help="Behavioral execution mode")
 @click.option("--mcp/--no-mcp", default=None, help="Enable/disable MCP auto-routing")
 @click.option("--tdd", is_flag=True, help="Enable TDD enforcement mode")
+@click.option("--no-loop", is_flag=True, default=False, help="Disable improvement loops (loops are ON by default)")
+@click.option("--loop", "loop_legacy", is_flag=True, hidden=True, help="[Deprecated] Loops are now default")
+@click.option("--iterations", type=int, default=None, help="Override max loop iterations")
 @click.pass_context
 def cli(
     ctx: click.Context,
@@ -53,10 +57,14 @@ def cli(
     think: bool,
     think_hard: bool,
     ultrathink: bool,
-    compact: bool,
+    no_compact: bool,
+    compact_legacy: bool,
     mode: str | None,
     mcp: bool | None,
     tdd: bool,
+    no_loop: bool,
+    loop_legacy: bool,
+    iterations: int | None,
 ) -> None:
     """ZERG - Parallel Claude Code execution system.
 
@@ -79,10 +87,24 @@ def cli(
             "Depth flags are mutually exclusive: --quick, --think, --think-hard, --ultrathink"
         )
     ctx.obj["depth"] = active[0] if active else "standard"
-    ctx.obj["compact"] = compact
+
+    # Compact: ON by default, --no-compact to disable
+    # Legacy --uc/--compact are no-ops (already default behavior)
+    if compact_legacy:
+        import warnings
+        warnings.warn("--uc/--compact is deprecated: compact is now default. Use --no-compact to disable.", DeprecationWarning, stacklevel=2)
+    ctx.obj["compact"] = not no_compact
+
     ctx.obj["mode"] = mode
     ctx.obj["mcp"] = mcp
     ctx.obj["tdd"] = tdd
+
+    # Loops: ON by default, --no-loop to disable
+    if loop_legacy:
+        import warnings
+        warnings.warn("--loop is deprecated: loops are now default. Use --no-loop to disable.", DeprecationWarning, stacklevel=2)
+    ctx.obj["loop"] = not no_loop
+    ctx.obj["iterations"] = iterations
 
 
 # Register implemented commands

--- a/zerg/commands/rush.py
+++ b/zerg/commands/rush.py
@@ -14,6 +14,7 @@ from rich.console import Console
 from rich.table import Table
 
 from zerg.backlog import update_backlog_task_status
+from zerg.capability_resolver import CapabilityResolver
 from zerg.config import ZergConfig
 from zerg.logging import get_logger, setup_logging
 from zerg.orchestrator import Orchestrator
@@ -154,8 +155,17 @@ def rush(
             console.print("[yellow]Aborted[/yellow]")
             return
 
+        # Resolve cross-cutting capabilities from CLI flags + config + task graph
+        resolver = CapabilityResolver()
+        capabilities = resolver.resolve(
+            cli_flags=ctx.obj,
+            config=config,
+            task_graph=task_data,
+            command="rush",
+        )
+
         # Create orchestrator and start
-        orchestrator = Orchestrator(feature, config, launcher_mode=mode)
+        orchestrator = Orchestrator(feature, config, launcher_mode=mode, capabilities=capabilities)
         launcher_name = type(orchestrator.launcher).__name__
         mode_label = "container (Docker)" if "Container" in launcher_name else "subprocess"
         console.print(f"Launcher mode: [bold]{mode_label}[/bold]")

--- a/zerg/context_plugin.py
+++ b/zerg/context_plugin.py
@@ -22,11 +22,15 @@ class ContextEngineeringPlugin(ContextPlugin):
     """Concrete context plugin that combines engineering rules, security rules, spec context, and command splitting.
 
     Budget allocation strategy for ``build_task_context``:
-        - Engineering rules: ~15% of task_context_budget_tokens
-        - Security rules summary:  ~15% of task_context_budget_tokens
-        - Spec context (relevant sections): ~35%
-        - MCP routing hints: ~15%
-        - Remaining ~20% is reserved as buffer / overhead
+        - Engineering rules: ~10% of task_context_budget_tokens
+        - Security rules summary: ~10%
+        - Spec context (relevant sections): ~25%
+        - MCP routing hints: ~10%
+        - Analysis depth guidance: ~10%
+        - Behavioral mode: ~10%
+        - TDD enforcement: ~10%
+        - Token efficiency hints: ~5%
+        - Remaining ~10% is reserved as buffer / overhead
     """
 
     def __init__(self, config: ContextEngineeringConfig | None = None) -> None:
@@ -121,31 +125,134 @@ class ContextEngineeringPlugin(ContextPlugin):
 
         sections: list[str] = []
 
-        # -- Engineering rules (~15% of budget) -----------------------------
-        rules_budget = int(budget * 0.15)
+        # -- Engineering rules (~10% of budget) -----------------------------
+        rules_budget = int(budget * 0.10)
         rules_section = self._build_rules_section(file_paths, rules_budget)
         if rules_section:
             sections.append(rules_section)
 
-        # -- Security rules (~15% of budget) --------------------------------
-        security_budget = int(budget * 0.15)
+        # -- Security rules (~10% of budget) --------------------------------
+        security_budget = int(budget * 0.10)
         security_section = self._build_security_section(file_paths, security_budget)
         if security_section:
             sections.append(security_section)
 
-        # -- Spec context (~35% of budget) ----------------------------------
-        spec_budget = int(budget * 0.35)
+        # -- Spec context (~25% of budget) ----------------------------------
+        spec_budget = int(budget * 0.25)
         spec_section = self._build_spec_section(task, feature, spec_budget)
         if spec_section:
             sections.append(spec_section)
 
-        # -- MCP routing hints (~15% of budget) -----------------------------
-        mcp_budget = int(budget * 0.15)
+        # -- MCP routing hints (~10% of budget) -----------------------------
+        mcp_budget = int(budget * 0.10)
         mcp_section = self._build_mcp_section(task, mcp_budget)
         if mcp_section:
             sections.append(mcp_section)
 
+        # -- Depth tier guidance (~10% of budget) ---------------------------
+        depth_budget = int(budget * 0.10)
+        depth_section = self._build_depth_section(depth_budget)
+        if depth_section:
+            sections.append(depth_section)
+
+        # -- Behavioral mode (~10% of budget) -------------------------------
+        mode_budget = int(budget * 0.10)
+        mode_section = self._build_mode_section(mode_budget)
+        if mode_section:
+            sections.append(mode_section)
+
+        # -- TDD enforcement (~10% of budget) -------------------------------
+        tdd_budget = int(budget * 0.10)
+        tdd_section = self._build_tdd_section(tdd_budget)
+        if tdd_section:
+            sections.append(tdd_section)
+
+        # -- Efficiency hints (~5% of budget) -------------------------------
+        efficiency_section = self._build_efficiency_section()
+        if efficiency_section:
+            sections.append(efficiency_section)
+
         return "\n\n".join(sections)
+
+    def _build_depth_section(self, max_tokens: int) -> str:
+        """Inject analysis depth guidance from ZERG_ANALYSIS_DEPTH env var."""
+        import os
+
+        depth = os.environ.get("ZERG_ANALYSIS_DEPTH", "")
+        if not depth or depth == "standard":
+            return ""
+
+        token_budgets = {
+            "quick": 1000,
+            "think": 4000,
+            "think_hard": 10000,
+            "ultrathink": 32000,
+        }
+        budget = token_budgets.get(depth, 2000)
+
+        guidance = {
+            "quick": "Surface-level analysis. Focus on obvious issues only. Be concise.",
+            "think": "Structured analysis. Consider component interactions. ~4K token budget.",
+            "think_hard": "Deep architectural analysis. Trace dependencies across modules. ~10K token budget.",
+            "ultrathink": "Maximum depth analysis. Full system-wide impact assessment. ~32K token budget.",
+        }
+        hint = guidance.get(depth, "Standard analysis depth.")
+
+        return f"## Analysis Depth: {depth}\n\nToken budget: {budget}\n{hint}"
+
+    def _build_mode_section(self, max_tokens: int) -> str:
+        """Inject behavioral mode instructions from ZERG_BEHAVIORAL_MODE env var."""
+        import os
+
+        mode = os.environ.get("ZERG_BEHAVIORAL_MODE", "")
+        if not mode or mode == "precision":
+            return ""
+
+        mode_instructions = {
+            "speed": "Prioritize fast delivery. Minimal validation. Skip non-essential checks.",
+            "exploration": "Explore alternatives. Consider multiple approaches before implementing.",
+            "refactor": "Focus on code quality. Improve structure, naming, and patterns.",
+            "debug": "Systematic debugging. Trace root causes. Add diagnostic logging.",
+        }
+        instruction = mode_instructions.get(mode, "")
+        if not instruction:
+            return ""
+
+        return f"## Behavioral Mode: {mode}\n\n{instruction}"
+
+    def _build_tdd_section(self, max_tokens: int) -> str:
+        """Inject TDD enforcement workflow from ZERG_TDD_MODE env var."""
+        import os
+
+        tdd = os.environ.get("ZERG_TDD_MODE", "")
+        if tdd != "1":
+            return ""
+
+        return (
+            "## TDD Enforcement\n\n"
+            "Follow RED \u2192 GREEN \u2192 REFACTOR workflow strictly:\n"
+            "1. **RED**: Write a failing test first that captures the requirement\n"
+            "2. **GREEN**: Write minimal code to make the test pass\n"
+            "3. **REFACTOR**: Clean up while keeping tests green\n\n"
+            "Do NOT write implementation code before tests exist."
+        )
+
+    def _build_efficiency_section(self) -> str:
+        """Inject token efficiency hints from ZERG_COMPACT_MODE env var."""
+        import os
+
+        compact = os.environ.get("ZERG_COMPACT_MODE", "")
+        if compact != "1":
+            return ""
+
+        return (
+            "## Token Efficiency\n\n"
+            "Compact mode is active. Minimize token usage:\n"
+            "- Use concise variable names in explanations\n"
+            "- Skip verbose comments on obvious code\n"
+            "- Prefer bullet points over paragraphs\n"
+            "- Omit redundant type annotations in documentation"
+        )
 
     def _build_rules_section(self, file_paths: list[str], max_tokens: int) -> str:
         """Inject engineering rules relevant to the task files.
@@ -225,6 +332,7 @@ class ContextEngineeringPlugin(ContextPlugin):
         """
         try:
             from zerg.mcp_router import MCPRouter
+            import os
 
             router = MCPRouter()
             file_paths = self._collect_task_files(task)
@@ -232,9 +340,13 @@ class ContextEngineeringPlugin(ContextPlugin):
                 {Path(f).suffix for f in file_paths if Path(f).suffix}
             )
 
+            # Use resolved depth tier if available
+            depth_tier = os.environ.get("ZERG_ANALYSIS_DEPTH")
+
             decision = router.route(
                 task_description=task.get("description", ""),
                 file_extensions=extensions,
+                depth_tier=depth_tier,
             )
 
             if decision.recommended_servers:

--- a/zerg/launcher.py
+++ b/zerg/launcher.py
@@ -36,6 +36,14 @@ ALLOWED_ENV_VARS = {
     "ZERG_ANALYSIS_DEPTH",
     "ZERG_COMPACT_MODE",
     "ZERG_MCP_HINT",
+    "ZERG_TOKEN_BUDGET",
+    "ZERG_BEHAVIORAL_MODE",
+    "ZERG_TDD_MODE",
+    "ZERG_RULES_ENABLED",
+    "ZERG_LOOP_ENABLED",
+    "ZERG_LOOP_ITERATIONS",
+    "ZERG_VERIFICATION_GATES",
+    "ZERG_STALENESS_THRESHOLD",
     # Claude Code cross-session coordination
     "CLAUDE_CODE_TASK_LIST_ID",
     # Common development env vars

--- a/zerg/worker_main.py
+++ b/zerg/worker_main.py
@@ -162,6 +162,20 @@ def main() -> int:
         if key.startswith("ZERG_"):
             os.environ[key] = value
 
+    # Log cross-cutting capability env vars at startup
+    capability_vars = {
+        k: v for k, v in os.environ.items()
+        if k.startswith("ZERG_") and k not in (
+            "ZERG_WORKER_ID", "ZERG_FEATURE", "ZERG_WORKTREE",
+            "ZERG_BRANCH", "ZERG_TASK_GRAPH", "ZERG_SPEC_DIR",
+            "ZERG_STATE_DIR", "ZERG_LOG_DIR", "ZERG_PORT",
+        )
+    }
+    if capability_vars:
+        print(f"Worker {args.worker_id} capabilities:", file=sys.stderr)
+        for k, v in sorted(capability_vars.items()):
+            print(f"  {k}={v}", file=sys.stderr)
+
     if args.dry_run:
         print(f"Worker {args.worker_id} validated successfully")
         print(f"  Feature: {args.feature}")

--- a/zerg/worker_protocol.py
+++ b/zerg/worker_protocol.py
@@ -77,6 +77,13 @@ class WorkerContext:
     branch: str
     context_threshold: float = DEFAULT_CONTEXT_THRESHOLD
 
+    # Cross-cutting capability fields (populated from ZERG_* env vars)
+    depth: str = "standard"
+    compact: bool = True
+    mode: str = "precision"
+    tdd: bool = False
+    mcp_hint: str = ""
+
 
 class WorkerProtocol:
     """Protocol handler for ZERG workers.


### PR DESCRIPTION
## Summary

- **Created `CapabilityResolver`** that bridges CLI flags + config + task graph into `ResolvedCapabilities` with `to_env_vars()` producing ZERG_* env vars for worker processes
- **Inverted compact/loop defaults** to ON by default (`--no-compact`, `--no-loop` to disable); deprecated `--uc`/`--compact`/`--loop` as hidden no-op aliases
- **Wired full data path**: `rush.py` → `Orchestrator` → `WorkerManager` → `launcher.spawn(env=)` → worker process → `context_plugin`
- **Added 4 capability sections** to context plugin (depth, mode, TDD, efficiency) with rebalanced budget (10/10/25/10/10/10/10/5/10)
- **Wired LoopController** into Orchestrator's level completion handler with gate-based scoring
- **Added GatePipeline** wrapper with artifact storage and staleness checking in `level_coordinator.py`
- **Extended WorkerContext** with capability fields; workers log ZERG_* capability env vars at startup
- **21 new tests** (13 unit + 8 integration); 7218 total tests pass

### Files changed (15)

| File | Change |
|------|--------|
| `zerg/capability_resolver.py` | **New** — resolver + env var mapping |
| `zerg/cli.py` | Flag inversions (compact/loop defaults ON) |
| `zerg/launcher.py` | Added ZERG_* env vars to allowlist |
| `zerg/commands/rush.py` | Resolve capabilities, pass to Orchestrator |
| `zerg/orchestrator.py` | Accept capabilities, wire LoopController |
| `zerg/worker_manager.py` | Pass `env=` to `launcher.spawn()` |
| `zerg/context_plugin.py` | 4 new capability sections, rebalanced budget |
| `zerg/worker_main.py` | Log capability env vars at startup |
| `zerg/worker_protocol.py` | Add capability fields to WorkerContext |
| `zerg/level_coordinator.py` | Add GatePipeline wrapper class |
| `tests/unit/test_capability_resolver.py` | **New** — 13 unit tests |
| `tests/integration/test_capability_wiring.py` | **New** — 8 integration tests |
| `CHANGELOG.md` | Unreleased entry |
| `CLAUDE.md` | Updated capabilities table |
| `docs/commands.md` | Updated flag documentation |

## Test plan

- [x] All 7218 existing tests pass (no regressions)
- [x] 21 new tests pass (capability resolver + wiring)
- [x] `python -m zerg.validate_commands` — all checks pass (no orphaned modules)
- [ ] Manual: `zerg --think --tdd rush --dry-run --feature test-feat` shows resolved capabilities
- [ ] Manual: verify `--no-compact` and `--no-loop` flags appear in `zerg --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)