### PR TITLE
feat: enforce CHANGELOG updates in design and ship workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- CHANGELOG enforcement: `/zerg:design` always includes a CHANGELOG.md update task in the quality level
+- CHANGELOG enforcement: `/zerg:git --action ship` validates CHANGELOG.md changes before pushing, warns if missing
 - Post-approval handoff prompt in `/zerg:plan` — AskUserQuestion with 3 next-step options after requirements approval (#94)
 - Documentation section (Section 10) added to requirements.md template referencing `/zerg:document` (#94)
 - Missing `/zerg:git` flags added to `docs/commands.md`: `--no-docker`, `--include-stashes`, `--limit`, `--priority` (#94)

--- a/zerg/data/commands/design.core.md
+++ b/zerg/data/commands/design.core.md
@@ -120,6 +120,7 @@ Depends on Integration.
 ### Phase 5: Quality (Level 5)
 Final polish.
 - Documentation
+- CHANGELOG.md update (required — add entries under [Unreleased])
 - Type coverage
 - Lint fixes
 ```
@@ -588,6 +589,7 @@ Reply with:
 - User has explicitly approved
 - Claude Tasks created for all tasks with correct dependencies
 - Consumer matrix populated for all tasks with created files
+- Task graph includes a CHANGELOG.md update task in the final quality level
 
 ## Help
 

--- a/zerg/data/commands/git.details.md
+++ b/zerg/data/commands/git.details.md
@@ -321,12 +321,22 @@ Non-interactive by default. Uses `mode=auto` for commit generation.
 **Pipeline steps:**
 
 1. **Commit** — Stage all changes, auto-generate conventional commit message, commit
-2. **Push** — Push branch to remote with `--set-upstream`
-3. **Create PR** — Create pull request via `gh pr create` with full context
-4. **Merge** — Merge PR via `gh pr merge --squash` (falls back to `--admin` if blocked)
-5. **Cleanup** — Switch to base, pull latest, delete feature branch (local + remote)
+2. **CHANGELOG check** — Run `git diff {base}...HEAD -- CHANGELOG.md`. If no changes found, use AskUserQuestion to warn:
+   - question: "CHANGELOG.md has no changes. PRs without CHANGELOG updates will fail CI."
+   - header: "CHANGELOG"
+   - options:
+     - label: "Add CHANGELOG entry now (Recommended)"
+       description: "Stop and add an entry under [Unreleased] before pushing"
+     - label: "Continue without CHANGELOG"
+       description: "Push anyway — use skip-changelog label on the PR if intentional"
+   - If user picks "Add CHANGELOG entry now", stop the pipeline and instruct them to edit CHANGELOG.md, then re-run `/zerg:git --action ship`
+   - If user picks "Continue without CHANGELOG", proceed to step 3
+3. **Push** — Push branch to remote with `--set-upstream`
+4. **Create PR** — Create pull request via `gh pr create` with full context
+5. **Merge** — Merge PR via `gh pr merge --squash` (falls back to `--admin` if blocked)
+6. **Cleanup** — Switch to base, pull latest, delete feature branch (local + remote)
 
-If `--no-merge` is set, stops after step 3. If any step fails, the pipeline stops and reports the failure point.
+If `--no-merge` is set, stops after step 4. If any step fails, the pipeline stops and reports the failure point.
 
 ---
 


### PR DESCRIPTION
## Summary
- `/zerg:design` Phase 5 (Quality) now always includes a CHANGELOG.md update task in the task graph, and completion criteria requires it
- `/zerg:git --action ship` validates CHANGELOG.md has changes before pushing; warns via AskUserQuestion if missing

## Test plan
- [ ] Verify `design.core.md` Quality level includes CHANGELOG bullet
- [ ] Verify `design.core.md` Completion Criteria includes CHANGELOG requirement
- [ ] Verify `git.details.md` ship pipeline has 6 steps with CHANGELOG check at step 2
- [ ] Verify CHANGELOG.md has entries under [Unreleased]

🤖 Generated with [Claude Code](https://claude.com/claude-code)