### PR TITLE
fix: add missing --tasks, --workers, --commits flags to status command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `/zerg:status` missing documented flags `--tasks`, `--workers`, `--commits` (#103)
+
 ### Added
 
 - 6 new `/z:analyze` check types: `dead-code`, `wiring`, `cross-file`, `conventions`, `import-chain`, `context-engineering`


### PR DESCRIPTION
## Summary

- Adds `--tasks` flag showing task table with Task ID, Status, Level, Worker, Description
- Adds `--workers` flag showing detailed worker info (container, port, branch, current task)
- Adds `--commits` flag showing recent commits per worker branch via `git log --oneline -5`

All flags work with existing `--feature` and `--level` filters.

## Test plan

- [x] `zerg status --help` lists all three new flags
- [x] `zerg status --tasks` renders task table
- [x] `zerg status --tasks --level 1` filters by level
- [x] `zerg status --workers` renders worker details
- [x] `zerg status --commits` renders commit history
- [x] Module wiring validation passes
- [x] Status-related tests pass

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)