### PR TITLE
fix(ci): add pytest-timeout to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "pytest-asyncio>=0.21",
     "pytest-xdist>=3.0",
     "pytest-split>=0.8",
+    "pytest-timeout>=2.0",
     "mypy>=1.0",
     "ruff>=0.14,<0.15",
     "pip-audit>=2.7.0",


### PR DESCRIPTION
## Summary

- Add `pytest-timeout>=2.0` to dev dependencies in pyproject.toml

## Problem

The smoke test job in CI uses `--timeout=5` flag but `pytest-timeout` was missing from dev dependencies, causing all smoke tests to fail with:

```
pytest: error: unrecognized arguments: --timeout=5
```

## Test plan

- [ ] CI smoke tests pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)