### PR TITLE
feat(commands): enforce workflow boundaries in plan and brainstorm

### DIFF
--- a/.gsd/specs/enforce-workflow-boundaries/design.md
+++ b/.gsd/specs/enforce-workflow-boundaries/design.md
@@ -1,0 +1,200 @@
+# Technical Design: enforce-workflow-boundaries
+
+## Metadata
+- **Feature**: enforce-workflow-boundaries
+- **Status**: APPROVED
+- **Created**: 2026-02-05
+- **Author**: /zerg:design
+
+---
+
+## 1. Overview
+
+### 1.1 Summary
+Add explicit WORKFLOW BOUNDARY sections to `/z:plan` and `/z:brainstorm` commands preventing auto-progression to the next workflow phase. This is prompt-level enforcement via documentation changes only.
+
+### 1.2 Goals
+- Prevent `/z:plan` from ever auto-running `/z:design` or implementation
+- Prevent `/z:brainstorm` from ever auto-running `/z:plan`
+- Ensure user maintains explicit control over workflow progression
+
+### 1.3 Non-Goals
+- Programmatic enforcement in Python code
+- Changes to `/z:design`, `/z:rush`, or other commands
+- CI/CD validation of workflow boundaries
+
+---
+
+## 2. Architecture
+
+### 2.1 High-Level Design
+
+No architecture changes. This is documentation-only.
+
+```
+┌─────────────────┐     HARD STOP     ┌─────────────────┐
+│  /z:brainstorm  │ ──────────────→   │     USER        │
+└─────────────────┘                   │  (manual run)   │
+                                      └────────┬────────┘
+                                               │
+                                               ▼
+┌─────────────────┐     HARD STOP     ┌─────────────────┐
+│    /z:plan      │ ──────────────→   │     USER        │
+└─────────────────┘                   │  (manual run)   │
+                                      └────────┬────────┘
+                                               │
+                                               ▼
+                                      ┌─────────────────┐
+                                      │   /z:design     │
+                                      └─────────────────┘
+```
+
+### 2.2 Component Breakdown
+
+| Component | Responsibility | Files |
+|-----------|---------------|-------|
+| plan.md | WORKFLOW BOUNDARY section, simplified Phase 5.5 | zerg/data/commands/plan.md |
+| plan.core.md | Same changes (keep in sync) | zerg/data/commands/plan.core.md |
+| brainstorm.md | WORKFLOW BOUNDARY section, AskUserQuestion handoff | zerg/data/commands/brainstorm.md |
+| brainstorm.core.md | Same changes (keep in sync) | zerg/data/commands/brainstorm.core.md |
+
+### 2.3 Data Flow
+
+N/A — Prompt documentation only.
+
+---
+
+## 3. Detailed Design
+
+### 3.1 WORKFLOW BOUNDARY Section Template
+
+Add at TOP of each command file (after title, before Flags):
+
+```markdown
+## ⛔ WORKFLOW BOUNDARY (NON-NEGOTIABLE)
+
+This command MUST NEVER:
+- Automatically run {next-command} or any {next-phase} phase
+- Automatically proceed to {downstream-phase}
+- Call the Skill tool to invoke another command
+- Write code or make code changes
+
+After Phase {N} completes, the command STOPS. The user must manually run {next-command}.
+```
+
+### 3.2 plan.md Changes
+
+1. Add WORKFLOW BOUNDARY section after title (before ## Flags)
+2. Update Phase 5.5 to remove "Run /z:design now" option (keep 2 options only)
+3. Add ⛔ warning after Phase 5.5
+
+### 3.3 brainstorm.md Changes
+
+1. Add WORKFLOW BOUNDARY section after title (before ## Flags)
+2. Update Phase 4 (Handoff) to use AskUserQuestion with 2 options
+3. Add ⛔ warning after Phase 4
+
+---
+
+## 4. Key Decisions
+
+### 4.1 Prompt-Level Enforcement Only
+
+**Context**: Could enforce workflow boundaries in Python orchestrator code.
+
+**Decision**: Prompt-level only
+
+**Rationale**: The issue is Claude's interpretation, not code behavior. Direct instruction is the fix.
+
+### 4.2 Remove "Run now" Option
+
+**Context**: Phase 5.5 of plan.md has "Run /z:design now" which could confuse.
+
+**Decision**: Remove it, keep only "Clear context, then /z:design" and "Stop here"
+
+**Rationale**: Eliminates any ambiguity about auto-execution permission.
+
+---
+
+## 5. Implementation Plan
+
+### 5.1 Phase Summary
+
+| Phase | Tasks | Parallel | Est. Time |
+|-------|-------|----------|-----------|
+| Core | 4 | Yes (pairs) | 10 min |
+
+### 5.2 File Ownership
+
+| File | Task ID | Operation |
+|------|---------|-----------|
+| zerg/data/commands/plan.md | TASK-001 | modify |
+| zerg/data/commands/plan.core.md | TASK-002 | modify |
+| zerg/data/commands/brainstorm.md | TASK-003 | modify |
+| zerg/data/commands/brainstorm.core.md | TASK-004 | modify |
+
+### 5.3 Dependency Graph
+
+```mermaid
+graph TD
+    T001[TASK-001: plan.md]
+    T002[TASK-002: plan.core.md]
+    T003[TASK-003: brainstorm.md]
+    T004[TASK-004: brainstorm.core.md]
+```
+
+All tasks are independent (Level 1). No dependencies.
+
+---
+
+## 6. Risk Assessment
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| Claude ignores HARD STOP | Low | Med | Use prominent ⛔ emoji and ALL CAPS |
+| Files get out of sync | Low | Low | Tasks update both .md and .core.md |
+
+---
+
+## 7. Testing Strategy
+
+### 7.1 Unit Tests
+N/A — No code changes.
+
+### 7.2 Integration Tests
+N/A — No code changes.
+
+### 7.3 Verification Commands
+
+Manual verification:
+- Read each modified file, confirm WORKFLOW BOUNDARY section present
+- Confirm plan.md Phase 5.5 has only 2 options
+- Confirm brainstorm.md Phase 4 has AskUserQuestion
+
+---
+
+## 8. Parallel Execution Notes
+
+### 8.1 Safe Parallelization
+- All 4 tasks are Level 1 (no dependencies)
+- Each task owns exactly one file
+- Can run all 4 in parallel
+
+### 8.2 Recommended Workers
+- Minimum: 1 worker
+- Optimal: 2 workers (plan pair + brainstorm pair)
+- Maximum: 4 workers
+
+### 8.3 Estimated Duration
+- Single worker: 10 min
+- With 2 workers: 5 min
+- Speedup: 2x
+
+---
+
+## 9. Approval
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|
+| Architecture | | | PENDING |
+| Engineering | | | PENDING |

--- a/.gsd/specs/enforce-workflow-boundaries/requirements.md
+++ b/.gsd/specs/enforce-workflow-boundaries/requirements.md
@@ -1,0 +1,168 @@
+# Requirements: Enforce Workflow Boundaries
+
+## Metadata
+- **Feature**: enforce-workflow-boundaries
+- **Status**: APPROVED
+- **Created**: 2026-02-05
+- **Author**: /zerg:plan
+
+---
+
+## 1. Problem Statement
+
+Currently, `/z:plan` and `/z:brainstorm` commands can potentially auto-progress to the next workflow step (design or plan respectively). The user explicitly requires that:
+
+1. **`/z:plan` MUST NEVER proceed directly to implementation or design** - it must always stop and prompt the user
+2. **`/z:brainstorm` MUST NEVER proceed directly to `/z:plan`** - it must always stop and prompt the user
+
+This is a workflow discipline requirement to ensure the user maintains full control over workflow progression.
+
+---
+
+## 2. Current State Analysis
+
+### `/z:plan` (plan.md, plan.core.md)
+- Phase 5.5 uses AskUserQuestion with 3 options after approval
+- Options include "Run /z:design now" - this is OUTPUT TEXT only, not auto-execution
+- **Gap**: No explicit HARD STOP language; Claude might interpret instructions loosely
+
+### `/z:brainstorm` (brainstorm.md, brainstorm.core.md)
+- Phase 4 (Handoff) only SUGGESTS next step: `/zerg:plan {top-feature}`
+- No AskUserQuestion mechanism for user to choose next step
+- **Gap**: Missing explicit handoff prompt; missing HARD STOP language
+
+---
+
+## 3. Functional Requirements
+
+### FR-1: Add Workflow Boundary Enforcement to `/z:plan`
+
+Add explicit HARD STOP rule at the top of the command file:
+
+```markdown
+## ⛔ WORKFLOW BOUNDARY (NON-NEGOTIABLE)
+
+This command MUST NEVER:
+- Automatically run `/z:design` or any design phase
+- Automatically proceed to implementation
+- Call the Skill tool to invoke another command
+- Write code or make code changes
+
+After Phase 5.5 completes, the command STOPS. The user must manually run `/z:design`.
+```
+
+### FR-2: Add Workflow Boundary Enforcement to `/z:brainstorm`
+
+Add explicit HARD STOP rule at the top of the command file:
+
+```markdown
+## ⛔ WORKFLOW BOUNDARY (NON-NEGOTIABLE)
+
+This command MUST NEVER:
+- Automatically run `/z:plan` or any planning phase
+- Automatically proceed to design or implementation
+- Call the Skill tool to invoke another command
+- Write code or make code changes
+
+After Phase 4 completes, the command STOPS. The user must manually run `/z:plan`.
+```
+
+### FR-3: Add AskUserQuestion Handoff to `/z:brainstorm`
+
+Update Phase 4 (Handoff) to use AskUserQuestion like `/z:plan` does:
+
+```markdown
+### Phase 4: Handoff
+
+Present ranked recommendations:
+1. Show prioritized feature list with effort estimates
+2. Save session summary to `.gsd/specs/{session-id}/brainstorm.md`
+
+**Then use AskUserQuestion to prompt the user for next steps:**
+
+Call AskUserQuestion:
+  - question: "Brainstorm complete! How would you like to proceed?"
+  - header: "Next step"
+  - options:
+    - label: "Clear context, then /z:plan (Recommended)"
+      description: "Run /compact to free token budget, then start /z:plan {top-feature} in fresh context"
+    - label: "Stop here"
+      description: "I'll run /z:plan later in a new session"
+
+Based on user response:
+- **"Clear context, then /z:plan"**: Output: "Run `/compact` to clear context, then run `/z:plan {top-feature}` to begin requirements."
+- **"Stop here"**: Command completes normally with no further output.
+
+**⛔ DO NOT auto-run /z:plan. The user must manually invoke it.**
+```
+
+### FR-4: Strengthen `/z:plan` Phase 5.5 Language
+
+Update Phase 5.5 to emphasize the HARD STOP:
+
+```markdown
+### Phase 5.5: Post-Approval Handoff
+
+After the user replies "APPROVED":
+
+1. First, call TaskUpdate to mark the plan task `completed`
+2. Update requirements.md with `Status: APPROVED`
+3. Then use AskUserQuestion to prompt the user for next steps:
+
+Call AskUserQuestion:
+  - question: "Requirements approved! How would you like to proceed?"
+  - header: "Next step"
+  - options:
+    - label: "Clear context, then /z:design (Recommended)"
+      description: "Run /compact to free token budget, then start /z:design in a fresh context"
+    - label: "Stop here"
+      description: "I'll run /z:design later in a new session"
+
+Based on user response:
+- **"Clear context, then /z:design"**: Output: "Run `/compact` to clear context, then run `/z:design` to begin architecture."
+- **"Stop here"**: Command completes normally with no further output.
+
+**⛔ DO NOT auto-run /z:design. DO NOT write code. The user must manually invoke the next command.**
+```
+
+**NOTE**: Remove the "Run /z:design now" option - it could be misinterpreted as permission to auto-run.
+
+---
+
+## 4. Files to Modify
+
+| File | Change |
+|------|--------|
+| `zerg/data/commands/plan.md` | Add workflow boundary section, strengthen Phase 5.5 |
+| `zerg/data/commands/plan.core.md` | Same changes (keep in sync) |
+| `zerg/data/commands/brainstorm.md` | Add workflow boundary section, add AskUserQuestion to Phase 4 |
+| `zerg/data/commands/brainstorm.core.md` | Same changes (keep in sync) |
+
+---
+
+## 5. Acceptance Criteria
+
+- [ ] `/z:plan` has explicit WORKFLOW BOUNDARY section at top
+- [ ] `/z:plan` Phase 5.5 has only 2 options (removes "Run now" option)
+- [ ] `/z:plan` has ⛔ warning after Phase 5.5
+- [ ] `/z:brainstorm` has explicit WORKFLOW BOUNDARY section at top
+- [ ] `/z:brainstorm` Phase 4 uses AskUserQuestion with 2 options
+- [ ] `/z:brainstorm` has ⛔ warning after Phase 4
+- [ ] Neither command can auto-invoke another command
+- [ ] User must manually run the next workflow step
+
+---
+
+## 6. Non-Functional Requirements
+
+- No code changes required (command files only)
+- No test changes required (behavioral documentation)
+- Changes should be applied to both `.md` and `.core.md` versions
+
+---
+
+## 7. Out of Scope
+
+- Programmatic enforcement (Python code) - this is prompt-level enforcement
+- Changes to `/z:design` or `/z:rush` commands
+- CI/CD validation of workflow boundaries

--- a/.gsd/specs/enforce-workflow-boundaries/task-graph.json
+++ b/.gsd/specs/enforce-workflow-boundaries/task-graph.json
@@ -1,0 +1,113 @@
+{
+  "feature": "enforce-workflow-boundaries",
+  "version": "2.0",
+  "generated": "2026-02-05T00:00:00Z",
+  "total_tasks": 4,
+  "estimated_duration_minutes": 10,
+  "max_parallelization": 4,
+
+  "tasks": [
+    {
+      "id": "TASK-001",
+      "title": "Add workflow boundary to plan.md",
+      "description": "Add WORKFLOW BOUNDARY section to plan.md. Update Phase 5.5 to remove 'Run /z:design now' option, keeping only 2 options. Add ⛔ warning after Phase 5.5.",
+      "phase": "core",
+      "level": 1,
+      "dependencies": [],
+      "files": {
+        "create": [],
+        "modify": ["zerg/data/commands/plan.md"],
+        "read": []
+      },
+      "verification": {
+        "command": "grep -q 'WORKFLOW BOUNDARY' zerg/data/commands/plan.md && grep -q 'MUST NEVER' zerg/data/commands/plan.md",
+        "timeout_seconds": 10
+      },
+      "estimate_minutes": 3,
+      "skills_required": ["markdown"],
+      "consumers": [],
+      "integration_test": null,
+      "context": "## Spec Context\nFR-1: Add explicit HARD STOP rule at the top of plan.md. The WORKFLOW BOUNDARY section must state this command MUST NEVER: automatically run /z:design, proceed to implementation, call Skill tool, or write code.\n\nFR-4: Update Phase 5.5 to have only 2 options (remove 'Run /z:design now'). Add ⛔ DO NOT auto-run warning."
+    },
+    {
+      "id": "TASK-002",
+      "title": "Add workflow boundary to plan.core.md",
+      "description": "Mirror changes from plan.md to plan.core.md. Add WORKFLOW BOUNDARY section, update Phase 5.5, add ⛔ warning.",
+      "phase": "core",
+      "level": 1,
+      "dependencies": [],
+      "files": {
+        "create": [],
+        "modify": ["zerg/data/commands/plan.core.md"],
+        "read": []
+      },
+      "verification": {
+        "command": "grep -q 'WORKFLOW BOUNDARY' zerg/data/commands/plan.core.md && grep -q 'MUST NEVER' zerg/data/commands/plan.core.md",
+        "timeout_seconds": 10
+      },
+      "estimate_minutes": 3,
+      "skills_required": ["markdown"],
+      "consumers": [],
+      "integration_test": null,
+      "context": "## Spec Context\nKeep plan.core.md in sync with plan.md. Same WORKFLOW BOUNDARY section and Phase 5.5 changes."
+    },
+    {
+      "id": "TASK-003",
+      "title": "Add workflow boundary to brainstorm.md",
+      "description": "Add WORKFLOW BOUNDARY section to brainstorm.md. Update Phase 4 (Handoff) to use AskUserQuestion with 2 options. Add ⛔ warning after Phase 4.",
+      "phase": "core",
+      "level": 1,
+      "dependencies": [],
+      "files": {
+        "create": [],
+        "modify": ["zerg/data/commands/brainstorm.md"],
+        "read": []
+      },
+      "verification": {
+        "command": "grep -q 'WORKFLOW BOUNDARY' zerg/data/commands/brainstorm.md && grep -q 'MUST NEVER' zerg/data/commands/brainstorm.md",
+        "timeout_seconds": 10
+      },
+      "estimate_minutes": 3,
+      "skills_required": ["markdown"],
+      "consumers": [],
+      "integration_test": null,
+      "context": "## Spec Context\nFR-2: Add explicit HARD STOP rule at the top of brainstorm.md. The WORKFLOW BOUNDARY section must state this command MUST NEVER: automatically run /z:plan, proceed to design/implementation, call Skill tool, or write code.\n\nFR-3: Update Phase 4 (Handoff) to use AskUserQuestion with 2 options: 'Clear context, then /z:plan (Recommended)' and 'Stop here'. Add ⛔ DO NOT auto-run warning."
+    },
+    {
+      "id": "TASK-004",
+      "title": "Add workflow boundary to brainstorm.core.md",
+      "description": "Mirror changes from brainstorm.md to brainstorm.core.md. Add WORKFLOW BOUNDARY section, update Phase 4, add ⛔ warning.",
+      "phase": "core",
+      "level": 1,
+      "dependencies": [],
+      "files": {
+        "create": [],
+        "modify": ["zerg/data/commands/brainstorm.core.md"],
+        "read": []
+      },
+      "verification": {
+        "command": "grep -q 'WORKFLOW BOUNDARY' zerg/data/commands/brainstorm.core.md && grep -q 'MUST NEVER' zerg/data/commands/brainstorm.core.md",
+        "timeout_seconds": 10
+      },
+      "estimate_minutes": 3,
+      "skills_required": ["markdown"],
+      "consumers": [],
+      "integration_test": null,
+      "context": "## Spec Context\nKeep brainstorm.core.md in sync with brainstorm.md. Same WORKFLOW BOUNDARY section and Phase 4 changes."
+    }
+  ],
+
+  "levels": {
+    "1": {
+      "name": "core",
+      "tasks": ["TASK-001", "TASK-002", "TASK-003", "TASK-004"],
+      "parallel": true,
+      "estimated_minutes": 10
+    }
+  },
+
+  "conflict_matrix": {
+    "description": "Tasks that cannot run in parallel due to shared files",
+    "conflicts": []
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Explicit workflow boundary enforcement in `/z:plan` and `/z:brainstorm` commands (#125)
+- ⛔ WORKFLOW BOUNDARY sections preventing auto-progression to next workflow phase
+- AskUserQuestion handoff to brainstorm.md Phase 4 for explicit user control
 - Architecture compliance quality gates with layer boundary, import restriction, and naming convention enforcement (#28)
 - `zerg/architecture.py` module with `ArchitectureChecker` and `ArchitectureConfig` for architecture validation
 - `ArchitectureGate` quality gate plugin for ship-time architecture validation (#28)

--- a/zerg/data/commands/brainstorm.core.md
+++ b/zerg/data/commands/brainstorm.core.md
@@ -3,6 +3,16 @@
 
 Discover opportunities and generate actionable GitHub issues for domain: **$ARGUMENTS**
 
+## ⛔ WORKFLOW BOUNDARY (NON-NEGOTIABLE)
+
+This command MUST NEVER:
+- Automatically run `/z:plan` or any planning phase
+- Automatically proceed to design or implementation
+- Call the Skill tool to invoke another command
+- Write code or make code changes
+
+After Phase 4 completes, the command STOPS. The user must manually run `/z:plan`.
+
 ## Flags
 
 - `--rounds N`: Number of Socratic rounds (default: 3, max: 5)
@@ -167,7 +177,23 @@ See details file for issue template.
 Present ranked recommendations:
 1. Show prioritized feature list with effort estimates
 2. Save session summary to `.gsd/specs/{session-id}/brainstorm.md`
-3. Suggest next step: `/zerg:plan {top-feature}`
+
+**Then use AskUserQuestion to prompt the user for next steps:**
+
+Call AskUserQuestion:
+  - question: "Brainstorm complete! How would you like to proceed?"
+  - header: "Next step"
+  - options:
+    - label: "Clear context, then /z:plan (Recommended)"
+      description: "Run /compact to free token budget, then start /z:plan {top-feature} in fresh context"
+    - label: "Stop here"
+      description: "I'll run /z:plan later in a new session"
+
+Based on user response:
+- **"Clear context, then /z:plan"**: Output: "Run `/compact` to clear context, then run `/z:plan {top-feature}` to begin requirements."
+- **"Stop here"**: Command completes normally with no further output.
+
+**⛔ DO NOT auto-run /z:plan. The user must manually invoke it.**
 
 ---
 

--- a/zerg/data/commands/brainstorm.md
+++ b/zerg/data/commands/brainstorm.md
@@ -2,6 +2,16 @@
 
 Discover opportunities and generate actionable GitHub issues for domain: **$ARGUMENTS**
 
+## ⛔ WORKFLOW BOUNDARY (NON-NEGOTIABLE)
+
+This command MUST NEVER:
+- Automatically run `/z:plan` or any planning phase
+- Automatically proceed to design or implementation
+- Call the Skill tool to invoke another command
+- Write code or make code changes
+
+After Phase 4 completes, the command STOPS. The user must manually run `/z:plan`.
+
 ## Flags
 
 - `--rounds N`: Number of Socratic rounds (default: 3, max: 5)
@@ -166,7 +176,23 @@ See details file for issue template.
 Present ranked recommendations:
 1. Show prioritized feature list with effort estimates
 2. Save session summary to `.gsd/specs/{session-id}/brainstorm.md`
-3. Suggest next step: `/zerg:plan {top-feature}`
+
+**Then use AskUserQuestion to prompt the user for next steps:**
+
+Call AskUserQuestion:
+  - question: "Brainstorm complete! How would you like to proceed?"
+  - header: "Next step"
+  - options:
+    - label: "Clear context, then /z:plan (Recommended)"
+      description: "Run /compact to free token budget, then start /z:plan {top-feature} in fresh context"
+    - label: "Stop here"
+      description: "I'll run /z:plan later in a new session"
+
+Based on user response:
+- **"Clear context, then /z:plan"**: Output: "Run `/compact` to clear context, then run `/z:plan {top-feature}` to begin requirements."
+- **"Stop here"**: Command completes normally with no further output.
+
+**⛔ DO NOT auto-run /z:plan. The user must manually invoke it.**
 
 ---
 

--- a/zerg/data/commands/plan.core.md
+++ b/zerg/data/commands/plan.core.md
@@ -3,6 +3,16 @@
 
 Capture complete requirements for feature: **$ARGUMENTS**
 
+## ⛔ WORKFLOW BOUNDARY (NON-NEGOTIABLE)
+
+This command MUST NEVER:
+- Automatically run `/z:design` or any design phase
+- Automatically proceed to implementation
+- Call the Skill tool to invoke another command
+- Write code or make code changes
+
+After Phase 5.5 completes, the command STOPS. The user must manually run `/z:design`.
+
 ## Flags
 
 - `--socratic` or `-s`: Use structured 3-round discovery mode (see details file)
@@ -114,15 +124,14 @@ Call AskUserQuestion:
   - options:
     - label: "Clear context, then /z:design (Recommended)"
       description: "Run /compact to free token budget, then start /z:design in a fresh context"
-    - label: "Run /z:design now"
-      description: "Continue in the current context — may have reduced token budget"
     - label: "Stop here"
       description: "I'll run /z:design later in a new session"
 
 Based on user response:
 - **"Clear context, then /z:design"**: Output: "Run `/compact` to clear context, then run `/z:design` to begin architecture."
-- **"Run /z:design now"**: Output: "Run `/z:design` now to begin architecture."
 - **"Stop here"**: Command completes normally with no further output.
+
+**⛔ DO NOT auto-run /z:design. DO NOT write code. The user must manually invoke the next command.**
 
 ---
 

--- a/zerg/data/commands/plan.md
+++ b/zerg/data/commands/plan.md
@@ -3,6 +3,16 @@
 
 Capture complete requirements for feature: **$ARGUMENTS**
 
+## ⛔ WORKFLOW BOUNDARY (NON-NEGOTIABLE)
+
+This command MUST NEVER:
+- Automatically run `/z:design` or any design phase
+- Automatically proceed to implementation
+- Call the Skill tool to invoke another command
+- Write code or make code changes
+
+After Phase 5.5 completes, the command STOPS. The user must manually run `/z:design`.
+
 ## Flags
 
 - `--socratic` or `-s`: Use structured 3-round discovery mode (see details file)
@@ -114,15 +124,14 @@ Call AskUserQuestion:
   - options:
     - label: "Clear context, then /z:design (Recommended)"
       description: "Run /compact to free token budget, then start /z:design in a fresh context"
-    - label: "Run /z:design now"
-      description: "Continue in the current context — may have reduced token budget"
     - label: "Stop here"
       description: "I'll run /z:design later in a new session"
 
 Based on user response:
 - **"Clear context, then /z:design"**: Output: "Run `/compact` to clear context, then run `/z:design` to begin architecture."
-- **"Run /z:design now"**: Output: "Run `/z:design` now to begin architecture."
 - **"Stop here"**: Command completes normally with no further output.
+
+**⛔ DO NOT auto-run /z:design. DO NOT write code. The user must manually invoke the next command.**
 
 ---
 


### PR DESCRIPTION
## Summary
- Add explicit ⛔ WORKFLOW BOUNDARY sections to prevent auto-progression
- `/z:plan` must never auto-run `/z:design` or proceed to implementation
- `/z:brainstorm` must never auto-run `/z:plan`
- Remove "Run /z:design now" option from plan.md Phase 5.5
- Add AskUserQuestion handoff to brainstorm.md Phase 4

## Test plan
- [ ] Verify WORKFLOW BOUNDARY section exists in all 4 command files
- [ ] Verify plan.md Phase 5.5 has only 2 options (not 3)
- [ ] Verify brainstorm.md Phase 4 has AskUserQuestion handoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)