### PR TITLE
feat(commands): add pre-execution validation to plan and design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Pre-execution validation for `/z:plan` and `/z:design` commands that checks git history, open PRs, and codebase for conflicts before proceeding
 - Explicit workflow boundary enforcement in `/z:plan` and `/z:brainstorm` commands (#125)
 - ⛔ WORKFLOW BOUNDARY sections preventing auto-progression to next workflow phase
 - AskUserQuestion handoff to brainstorm.md Phase 4 for explicit user control

--- a/zerg/data/commands/design.core.md
+++ b/zerg/data/commands/design.core.md
@@ -27,6 +27,61 @@ if ! grep -q "Status.*APPROVED" "$SPEC_DIR/requirements.md" 2>/dev/null; then
 fi
 ```
 
+## Phase 0: Pre-Execution Validation
+
+Before proceeding, validate this design is still needed:
+
+1. **Read Requirements**
+   - Load `.gsd/specs/$FEATURE/requirements.md`
+   - Extract key objectives and target files
+
+2. **Check Recent Commits**
+   ```bash
+   git log --oneline -20
+   ```
+   - Compare commit messages against requirements objectives
+
+3. **Check Open PRs**
+   ```bash
+   gh pr list --state open
+   ```
+   - Check for PRs implementing similar features
+
+4. **Grep Targets**
+   - For each file in requirements' "Files to Create/Modify":
+     ```bash
+     ls {target_file} 2>/dev/null && echo "EXISTS: {target_file}"
+     ```
+   - For key function/class names mentioned:
+     ```bash
+     grep -r "{identifier}" zerg/ tests/ --include="*.py" -l | head -5
+     ```
+
+5. **Validation Decision**
+   IF requirements.md missing:
+     ERROR: Run /z:plan first
+
+   IF target files already exist OR key identifiers found:
+     STOP and present:
+     ```
+     ⚠️  VALIDATION WARNING
+
+     Potential conflict detected:
+     - [Commits/PRs/Code/Files] matching feature found
+
+     Options:
+     1. Update plan - Revise spec to account for existing work
+     2. Archive - Move to .gsd/specs/_archived/
+     3. Proceed anyway - Override and continue
+     ```
+
+     Use AskUserQuestion to get user decision.
+
+   IF validation passes:
+     Continue to Load Context.
+
+---
+
 ## Load Context
 
 Read thoroughly:

--- a/zerg/data/commands/plan.core.md
+++ b/zerg/data/commands/plan.core.md
@@ -42,6 +42,52 @@ echo "$FEATURE" > .gsd/.current-feature
 echo "$(date -Iseconds)" > ".gsd/specs/$FEATURE/.started"
 ```
 
+## Phase 0: Pre-Execution Validation
+
+Before proceeding, validate this plan hasn't been superseded:
+
+1. **Extract Objective**
+   - Read `.gsd/specs/$FEATURE/requirements.md` if exists
+   - Identify key terms: feature name, main components, file patterns
+
+2. **Check Recent Commits**
+   ```bash
+   git log --oneline -20 | grep -i "$FEATURE"
+   ```
+   - Flag if any commits mention the feature name
+
+3. **Check Open PRs**
+   ```bash
+   gh pr list --state open | grep -i "$FEATURE"
+   ```
+   - Flag if any open PRs match
+
+4. **Search Codebase**
+   - Grep for key implementation patterns from the requirements
+   - Flag if substantial matches found (>5 files)
+
+5. **Validation Decision**
+   IF any checks flag potential conflicts:
+     STOP and present:
+     ```
+     ⚠️  VALIDATION WARNING
+
+     Potential conflict detected:
+     - [Commits/PRs/Code] matching "{feature}" found
+
+     Options:
+     1. Update plan - Revise spec to account for existing work
+     2. Archive - Move to .gsd/specs/_archived/
+     3. Proceed anyway - Override and continue
+     ```
+
+     Use AskUserQuestion to get user decision.
+
+   IF validation passes:
+     Continue to Enter Plan Mode.
+
+---
+
 ## Enter Plan Mode
 
 **Press Shift+Tab twice** to enter plan mode (Opus 4.5 for reasoning).


### PR DESCRIPTION
## Summary
- Add Phase 0: Pre-Execution Validation to `/z:plan` and `/z:design` commands
- Checks git history, open PRs, and codebase for conflicts before proceeding
- Presents user with options to update, archive, or proceed anyway if conflicts detected

## Changes
- `zerg/data/commands/plan.core.md`: Add validation before "Enter Plan Mode"
- `zerg/data/commands/design.core.md`: Add validation before "Load Context"
- `CHANGELOG.md`: Document new feature

## Test plan
- [x] Verification commands pass for both modified files
- [x] CHANGELOG updated under [Unreleased]

🤖 Generated with [Claude Code](https://claude.com/claude-code)