### PR TITLE
feat: add --admin flag to /zerg:git ship action

### DIFF
--- a/.gsd/wiki/Command-Reference.md
+++ b/.gsd/wiki/Command-Reference.md
@@ -2542,7 +2542,7 @@ Found culprit: ghi9012
 /zerg:git --action ship
 ```
 
-Runs commit, push, PR create, merge, and cleanup in one shot.
+Runs commit, push, PR create, merge, and cleanup in one shot. Use `--admin` to bypass branch protection rules directly.
 
 **Flags:**
 
@@ -2560,6 +2560,8 @@ Runs commit, push, PR create, merge, and cleanup in one shot.
 | `--test-cmd` | | string | "" | Test command (bisect) |
 | `--good` | | string | "" | Known good ref (bisect) |
 | `--dry-run` | | boolean | false | Preview without executing |
+| `--no-merge` | | boolean | false | Stop after PR creation |
+| `--admin` | | boolean | false | Use admin merge directly (repo owner/admin) |
 
 ---
 

--- a/.gsd/wiki/Tutorial.md
+++ b/.gsd/wiki/Tutorial.md
@@ -773,6 +773,12 @@ All Levels Complete
 /zerg:git --action ship
 ```
 
+**Ship with admin merge (bypass branch protection):**
+
+```
+/zerg:git --action ship --admin
+```
+
 **Full workflow (commit + PR + merge):**
 
 ```

--- a/.zerg/wiki/zerg-git.md
+++ b/.zerg/wiki/zerg-git.md
@@ -14,7 +14,7 @@ Git operations with intelligent commits, PR creation, releases, rescue, review, 
           [--focus security|performance|quality|architecture]
           [--symptom TEXT] [--test-cmd CMD] [--good REF]
           [--list-ops] [--undo] [--restore TAG] [--recover-branch NAME]
-          [--no-merge]
+          [--no-merge] [--admin]
           [--scan] [--title TEXT] [--dry-run]
           [--no-docker] [--include-stashes]
           [--limit N] [--label LABEL] [--priority P0|P1|P2]
@@ -105,7 +105,7 @@ Which option?
 **ship** -- Full delivery pipeline: commit, push, create PR, merge, and cleanup in one shot. Non-interactive. Uses auto mode for commit generation. Tries regular merge first, falls back to admin merge if blocked by branch protection.
 
 ```
-/zerg:git --action ship [--base main] [--draft] [--reviewer USER] [--no-merge]
+/zerg:git --action ship [--base main] [--draft] [--reviewer USER] [--no-merge] [--admin]
 ```
 
 **cleanup** -- Repository hygiene: prune merged branches, stale remote refs, orphaned worktrees, and ZERG Docker resources. Auto-detects stopped containers. Use `--no-docker` to skip Docker cleanup, `--include-stashes` to clear stashes, `--dry-run` to preview.
@@ -160,6 +160,7 @@ Auto-generated commit messages follow the conventional commits specification:
 | `--restore` | -- | Restore repository state from a snapshot tag (for `rescue` action). |
 | `--recover-branch` | -- | Recover a deleted branch from the reflog (for `rescue` action). |
 | `--no-merge` | off | Stop after PR creation, skip merge and cleanup (for `ship` action). |
+| `--admin` | off | Use admin merge directly, bypassing branch protection (for `ship` action). |
 | `--scan` | on | Auto-detect issues from codebase analysis (default for `issue` action). |
 | `--title` | -- | Issue title; switches `issue` action to description mode. |
 | `--no-docker` | off | Skip Docker container/image cleanup (for `cleanup` action). |
@@ -312,6 +313,12 @@ Ship with draft PR for team review:
 
 ```
 /zerg:git --action ship --no-merge --draft --reviewer octocat
+```
+
+Ship with admin merge (repo owner bypassing branch protection):
+
+```
+/zerg:git --action ship --admin
 ```
 
 Cleanup merged branches, stale refs, and Docker resources:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `--admin` flag for `/zerg:git --action ship`: use admin merge directly, bypassing branch protection rules (repo owner/admin)
 - `zerg/state/` package: decompose 1010-line StateManager into 9 focused modules with facade pattern
 - `zerg/fs_utils.py`: single-pass file traversal utility replacing scattered rglob calls
 - `zerg/json_utils.py`: orjson/stdlib abstraction with optional `orjson` dependency for performance

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Other git operations available:
 |--------|---------|---------|
 | Commit | `/zerg:git commit` | Commit current changes with generated message |
 | Create PR | `/zerg:git --action pr` | Open pull request for review |
-| Ship | `/zerg:git --action ship` | Merge to main after verification |
+| Ship | `/zerg:git --action ship` | Merge to main after verification (`--admin` to bypass branch protection) |
 | Full workflow | `/zerg:git --action finish` | PR → review → merge in one command |
 
 ---

--- a/docs/commands-quick.md
+++ b/docs/commands-quick.md
@@ -330,6 +330,7 @@ Git operations with intelligent commits, PRs, releases, and more.
 | `--restore` | string | "" | Restore snapshot |
 | `--recover-branch` | string | "" | Recover deleted branch |
 | `--no-merge` | bool | false | Stop after PR creation |
+| `--admin` | bool | false | Use admin merge directly (repo owner/admin, for ship) |
 | `--stale-days` | int | 30 | Branch age for cleanup |
 | `--title` | string | "" | Issue title |
 | `--label` | string | "" | Issue label |

--- a/zerg/data/commands/git.core.md
+++ b/zerg/data/commands/git.core.md
@@ -24,7 +24,7 @@ Git operations with intelligent commits, PR creation, releases, rescue, review, 
 | review | Pre-review context assembly | --focus |
 | rescue | Undo/recovery operations | --list-ops, --undo, --restore, --recover-branch |
 | bisect | AI-powered bug bisection | --symptom, --test-cmd, --good |
-| ship | Commit, push, PR, merge, cleanup in one shot | --base, --draft, --reviewer, --no-merge |
+| ship | Commit, push, PR, merge, cleanup in one shot | --base, --draft, --reviewer, --no-merge, --admin |
 | cleanup | Repository hygiene: prune branches, refs, worktrees, Docker | --dry-run, --no-docker, --include-stashes |
 | issue | Create AI-optimized GitHub issues from scan or description | --scan, --title, --dry-run, --limit, --label, --priority |
 
@@ -53,6 +53,7 @@ Git operations with intelligent commits, PR creation, releases, rescue, review, 
 --restore TAG          Restore snapshot tag (rescue)
 --recover-branch NAME  Recover deleted branch (rescue)
 --no-merge             Stop after PR creation (skip merge+cleanup)
+--admin                Use admin merge directly (repo owner/admin, for ship)
 --scan                 Auto-detect issues from codebase analysis (default for issue action)
 --title TEXT           Issue title (for issue action, switches to description mode)
 --no-docker            Skip Docker container/image cleanup (for cleanup action)

--- a/zerg/data/commands/git.details.md
+++ b/zerg/data/commands/git.details.md
@@ -325,6 +325,9 @@ Non-interactive by default. Uses `mode=auto` for commit generation.
 
 # Ship to a different base branch
 /zerg:git --action ship --base develop
+
+# Ship with admin merge (repo owner bypassing branch protection)
+/zerg:git --action ship --admin
 ```
 
 **Pipeline steps:**
@@ -342,7 +345,7 @@ Non-interactive by default. Uses `mode=auto` for commit generation.
    - If user picks "Continue without CHANGELOG", proceed to step 3
 3. **Push** — Push branch to remote with `--set-upstream`
 4. **Create PR** — Create pull request via `gh pr create` with full context
-5. **Merge** — Merge PR via `gh pr merge --squash` (falls back to `--admin` if blocked)
+5. **Merge** — Merge PR via `gh pr merge --squash` (falls back to `--admin` if blocked; with `--admin` flag, uses admin merge directly)
 6. **Cleanup** — Switch to base, pull latest, delete feature branch (local + remote)
 
 If `--no-merge` is set, stops after step 4. If any step fails, the pipeline stops and reports the failure point.
@@ -545,6 +548,7 @@ Flags:
   --restore TAG         Restore snapshot (rescue)
   --recover-branch NAME Recover branch (rescue)
   --no-merge            Stop after PR creation (skip merge+cleanup)
+  --admin               Use admin merge directly (repo owner/admin, for ship)
   --scan                Auto-detect issues from codebase (issue action)
   --title TEXT          Issue title (issue action, description mode)
   --no-docker           Skip Docker cleanup (cleanup action)

--- a/zerg/data/commands/git.md
+++ b/zerg/data/commands/git.md
@@ -24,7 +24,7 @@ Git operations with intelligent commits, PR creation, releases, rescue, review, 
 | review | Pre-review context assembly | --focus |
 | rescue | Undo/recovery operations | --list-ops, --undo, --restore, --recover-branch |
 | bisect | AI-powered bug bisection | --symptom, --test-cmd, --good |
-| ship | Commit, push, PR, merge, cleanup in one shot | --base, --draft, --reviewer, --no-merge |
+| ship | Commit, push, PR, merge, cleanup in one shot | --base, --draft, --reviewer, --no-merge, --admin |
 | cleanup | Repository hygiene: prune branches, refs, worktrees, Docker | --dry-run, --no-docker, --include-stashes |
 | issue | Create AI-optimized GitHub issues from scan or description | --scan, --title, --dry-run, --limit, --label, --priority |
 
@@ -53,6 +53,7 @@ Git operations with intelligent commits, PR creation, releases, rescue, review, 
 --restore TAG          Restore snapshot tag (rescue)
 --recover-branch NAME  Recover deleted branch (rescue)
 --no-merge             Stop after PR creation (skip merge+cleanup)
+--admin                Use admin merge directly (repo owner/admin, for ship)
 --scan                 Auto-detect issues from codebase analysis (default for issue action)
 --title TEXT           Issue title (for issue action, switches to description mode)
 --no-docker            Skip Docker container/image cleanup (for cleanup action)
@@ -128,6 +129,7 @@ Flags:
   --recover-branch NAME
                     Recover branch (rescue)
   --no-merge        Stop after PR creation (skip merge+cleanup)
+  --admin           Use admin merge directly (repo owner/admin, for ship)
   --scan            Auto-detect issues from codebase (issue action)
   --title TEXT      Issue title (issue action, description mode)
   --no-docker       Skip Docker cleanup (cleanup action)


### PR DESCRIPTION
## Summary

Adds explicit `--admin` flag to `/zerg:git --action ship` so repo owners can bypass branch protection rules directly instead of relying on the silent fallback that tries regular merge first.

**Scope analysis**: Only `ship` needs `--admin` — it's the only action that calls `gh pr merge`. All other actions (`merge`, `finish`, etc.) use local git operations.

## Changes
- **`zerg/commands/git_cmd.py`**: Click option, function signatures, dispatch, merge logic (admin=True skips doomed regular-merge attempt)
- **10 documentation files updated**: git.md, git.core.md, git.details.md, wiki/zerg-git.md, README.md, docs/commands-quick.md, .gsd/wiki/Command-Reference.md, .gsd/wiki/Tutorial.md, CHANGELOG.md

## Test plan
- [x] `python -m pytest tests/ -k git` — 198 passed
- [x] `python -m zerg.validate_commands` — all checks passed
- [x] `zerg git --help` — `--admin` appears in help output
- [x] `grep -rn "\-\-admin"` confirms presence in all 10 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)