### PR TITLE
feat: add --tone flag, plan guards, and doc impact tracking (#129, #163, #165)

### DIFF
--- a/.gsd/.current-feature
+++ b/.gsd/.current-feature
@@ -1,1 +1,1 @@
-test-suite-reduction-phase678
+github-issues-129-163-165

--- a/.gsd/specs/github-issues-129-163-165/design.md
+++ b/.gsd/specs/github-issues-129-163-165/design.md
@@ -1,0 +1,316 @@
+# Technical Design: github-issues-129-163-165
+
+## Metadata
+- **Feature**: github-issues-129-163-165
+- **Status**: DRAFT
+- **Created**: 2026-02-07
+- **Author**: Factory Design Mode
+
+---
+
+## 1. Overview
+
+### 1.1 Summary
+Three prompt-level and one code-level change across ZERG's documentation, planning, and design commands. The `--tone` flag adds tone-controlled documentation generation to `/zerg:document` (with 3 tone definition files). Anti-implementation guards harden `/z:plan` against workflow drift. A new Section 11 in the plan template and mandatory doc tasks in the design command ensure documentation stays current. All project docs are updated to reflect these changes.
+
+### 1.2 Goals
+- Educational documentation as default output from `/zerg:document`
+- Zero-tolerance plan→design→rush workflow boundary enforcement
+- Documentation drift eliminated via systematic impact tracking
+
+### 1.3 Non-Goals
+- Python-level runtime enforcement of workflow boundaries (deferred)
+- Programmatic tone transformation engine (tone is prompt-level)
+- Splitting `document.md` (stays under 300 lines)
+
+---
+
+## 2. Architecture
+
+### 2.1 High-Level Design
+
+```
+┌─────────────────────────────────────────────────────┐
+│                 Slash Commands (prompt layer)        │
+│                                                     │
+│  ┌──────────┐  ┌──────────┐  ┌──────────────────┐  │
+│  │ plan.md  │  │design.md │  │  document.md     │  │
+│  │ +guards  │  │ +doc     │  │  +--tone flag    │  │
+│  │          │  │  tasks   │  │  reads tone/*.md │  │
+│  └──────────┘  └──────────┘  └──────────────────┘  │
+│                                       │             │
+│                              ┌────────▼─────────┐   │
+│                              │ zerg/data/tones/  │   │
+│                              │ ├ educational.md  │   │
+│                              │ ├ reference.md    │   │
+│                              │ └ tutorial.md     │   │
+│                              └──────────────────┘   │
+│                                                     │
+│  ┌──────────────────────────────────────────────┐   │
+│  │ zerg/commands/document.py  (+--tone option)  │   │
+│  └──────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────┘
+```
+
+### 2.2 Component Breakdown
+
+| Component | Responsibility | Files |
+|-----------|---------------|-------|
+| Tone Definitions | Define output style for each tone | `zerg/data/tones/{educational,reference,tutorial}.md` |
+| Document Command (Python) | Parse `--tone` flag, pass to renderer | `zerg/commands/document.py` |
+| Document Command (Prompt) | Instruct Claude to load and apply tone | `zerg/data/commands/document.md` |
+| Plan Core (Prompt) | Anti-implementation guards at 4+ locations | `zerg/data/commands/plan.core.md` |
+| Plan Parent (Prompt) | Sync guards with core file | `zerg/data/commands/plan.md` |
+| Plan Details (Prompt) | Section 11 in requirements template | `zerg/data/commands/plan.details.md` |
+| Design Core (Prompt) | Mandatory doc task generation | `zerg/data/commands/design.core.md` |
+| Design Parent (Prompt) | Sync doc task guidance with core | `zerg/data/commands/design.md` |
+| Project Docs | Keep docs current with changes | README, CHANGELOG, wiki, command refs |
+
+### 2.3 Data Flow
+
+1. User invokes `/zerg:document target --tone educational`
+2. Click parses `--tone` flag (default: `educational`)
+3. Python passes tone to DocRenderer
+4. Prompt layer reads `zerg/data/tones/educational.md` for style instructions
+5. DocRenderer generates documentation following tone guidelines
+6. Output to stdout or `--output` path
+
+---
+
+## 3. Detailed Design
+
+### 3.1 Tone Flag (document.py)
+
+```python
+@click.option(
+    "--tone",
+    type=click.Choice(["educational", "reference", "tutorial"]),
+    default="educational",
+    help="Documentation tone (default: educational)",
+)
+```
+
+The tone string is passed to DocRenderer.render() and stored for prompt-layer use. The renderer loads the corresponding tone definition file.
+
+### 3.2 Tone Definition Files
+
+Each tone file at `zerg/data/tones/{tone}.md` contains:
+- Tone name and description
+- Output structure template
+- Required sections per concept
+- Example output format
+
+**Educational** (default): CONCEPT → NARRATIVE → DIAGRAM → COMMAND sections for every concept. Explanatory, teaches "why" not just "what".
+
+**Reference**: Terse tables, API signatures, parameter lists. Current behavior preserved for backward compatibility.
+
+**Tutorial**: Step-by-step walkthrough with simulated dialogue, progressive complexity.
+
+### 3.3 Plan Anti-Implementation Guards
+
+Four guard locations in `plan.core.md`:
+1. **Top-of-file banner** (existing, strengthen)
+2. **Before Phase 2** (new) — "DO NOT write code"
+3. **Before Phase 5** (new) — "DO NOT proceed to design"
+4. **Post-approval section** (existing, strengthen) — "PLANNING COMPLETE" banner
+
+Terminal output format:
+```
+═══════════════════════════════════════════════════════════════
+                    ⛔ PLANNING COMPLETE ⛔
+═══════════════════════════════════════════════════════════════
+
+This command has finished. DO NOT proceed to implementation.
+The user must manually run /z:design to continue.
+
+EXIT NOW — do not write code, do not invoke other commands.
+═══════════════════════════════════════════════════════════════
+```
+
+### 3.4 Documentation Impact Analysis (Section 11)
+
+Added to `plan.details.md` requirements template after Section 10:
+
+```markdown
+## 11. Documentation Impact Analysis
+
+### 11.1 Files Requiring Documentation Updates
+| File | Current State | Required Update | Priority |
+|------|--------------|-----------------|----------|
+
+### 11.2 Documentation Tasks for Design Phase
+- [ ] CHANGELOG.md update task (ALWAYS required)
+- [ ] README.md update (if applicable)
+- [ ] Command reference updates (if command/flag functionality changed)
+- [ ] CLAUDE.md update (if project conventions changed)
+- [ ] Wiki updates (if user-facing behavior changed)
+```
+
+### 3.5 Mandatory Doc Tasks in Design
+
+`design.core.md` gets a new subsection in Phase 2 requiring:
+- CHANGELOG.md task ALWAYS in Level 5
+- Doc update tasks when command/flag behavior changes
+
+---
+
+## 4. Key Decisions
+
+### 4.1 Tone as Prompt-Level Directive
+
+**Context**: Need to control documentation output style.
+
+**Options Considered**:
+1. Programmatic tone engine in Python: Complex, requires template system
+2. Prompt-level directive via tone files: Simple, extensible, no code complexity
+3. Hardcoded tone templates in renderer: Not extensible
+
+**Decision**: Prompt-level directive (option 2)
+
+**Rationale**: Adding a tone file = adding a new tone. No code changes needed. Claude reads the tone file and follows its instructions. This is the simplest approach that works.
+
+**Consequences**: Tone quality depends on prompt engineering, not code logic. New tones are trivially added.
+
+### 4.2 Guard Placement Strategy
+
+**Context**: `/z:plan` sometimes auto-implements despite existing guard.
+
+**Options Considered**:
+1. Single stronger guard at top: Insufficient — Claude forgets by Phase 5
+2. Redundant guards at 4 locations: Repetitive but effective
+3. Python-level enforcement: Complex, requires intercepting tool calls
+
+**Decision**: Redundant guards at 4 locations (option 2)
+
+**Rationale**: Claude's context window means single guards get forgotten. Redundancy at decision boundaries (before code-touching phases) is the most cost-effective prevention.
+
+**Consequences**: Slightly longer command file but well within 300-line split threshold.
+
+---
+
+## 5. Implementation Plan
+
+### 5.1 Phase Summary
+
+| Phase | Tasks | Parallel | Est. Time |
+|-------|-------|----------|-----------|
+| Foundation (L1) | 3 | Yes | 15 min |
+| Core (L2) | 3 | Yes | 20 min |
+| Integration (L3) | 2 | Yes | 15 min |
+| Testing (L4) | 1 | No | 15 min |
+| Quality (L5) | 2 | Yes | 15 min |
+
+### 5.2 File Ownership
+
+| File | Task ID | Operation |
+|------|---------|-----------|
+| `zerg/data/tones/educational.md` | TASK-001 | create |
+| `zerg/data/tones/reference.md` | TASK-002 | create |
+| `zerg/data/tones/tutorial.md` | TASK-003 | create |
+| `zerg/commands/document.py` | TASK-004 | modify |
+| `zerg/data/commands/document.md` | TASK-004 | modify |
+| `zerg/data/commands/plan.core.md` | TASK-005 | modify |
+| `zerg/data/commands/plan.md` | TASK-005 | modify |
+| `zerg/data/commands/plan.details.md` | TASK-006 | modify |
+| `zerg/data/commands/design.core.md` | TASK-007 | modify |
+| `zerg/data/commands/design.md` | TASK-007 | modify |
+| `tests/unit/test_document_tone.py` | TASK-008 | create |
+| `CHANGELOG.md` | TASK-009 | modify |
+| `README.md` | TASK-009 | modify |
+| `docs/commands-quick.md` | TASK-009 | modify |
+| `docs/commands-deep.md` | TASK-009 | modify |
+| `.gsd/wiki/Command-Reference.md` | TASK-010 | modify |
+| `.gsd/wiki/Tutorial.md` | TASK-010 | modify |
+| `CLAUDE.md` | TASK-010 | modify |
+
+### 5.3 Dependency Graph
+
+```mermaid
+graph TD
+    T001[TASK-001: Educational tone] --> T004[TASK-004: Document --tone flag]
+    T002[TASK-002: Reference tone] --> T004
+    T003[TASK-003: Tutorial tone] --> T004
+    T004 --> T008[TASK-008: Unit tests]
+    T005[TASK-005: Plan guards] --> T008
+    T006[TASK-006: Plan Section 11] --> T008
+    T007[TASK-007: Design doc tasks] --> T008
+    T008 --> T009[TASK-009: Project docs batch 1]
+    T008 --> T010[TASK-010: Project docs batch 2]
+    T008 --> T011[TASK-011: Wiring verification]
+```
+
+---
+
+## 6. Risk Assessment
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| Plan guards insufficient (Claude ignores them) | Low | Med | 4 redundant locations + terminal banner |
+| Tone files too vague for consistent output | Med | Low | Include concrete examples in each tone file |
+| document.md exceeds 300-line split threshold | Low | Low | Monitor line count, split if needed |
+| Parent/core file sync drift | Med | Med | Modify both in same task |
+
+---
+
+## 7. Testing Strategy
+
+### 7.1 Unit Tests
+- `--tone` flag parsing: default (educational), explicit (reference, tutorial), invalid (error)
+- `--tone` passed to renderer correctly
+- Tone definition files exist at expected paths
+
+### 7.2 Integration Tests
+- `validate_commands` passes after all changes
+- No drift in command files (Task tool references preserved)
+
+### 7.3 Verification Commands
+- `python -m pytest tests/unit/test_document_tone.py -x -q`
+- `python -m zerg.validate_commands`
+- `grep -c "MUST NEVER" zerg/data/commands/plan.core.md` (expect >= 4 guard markers)
+
+---
+
+## 8. Parallel Execution Notes
+
+### 8.1 Safe Parallelization
+- Level 1: 3 tone files, fully parallel, no shared files
+- Level 2: 3 tasks modifying disjoint command files, fully parallel
+- Level 3: 2 doc tasks modifying disjoint doc sets, fully parallel
+- No two tasks modify the same file
+
+### 8.2 Recommended Workers
+- Minimum: 1 worker (sequential by level)
+- Optimal: 3 workers (widest level is L1/L2 at 3 tasks)
+- Maximum: 3 workers (only 3 parallel at widest)
+
+### 8.3 Estimated Duration
+- Single worker: ~80 min
+- With 3 workers: ~45 min
+- Speedup: ~1.8x
+
+---
+
+## 9. Consumer Matrix
+
+| Task | Creates/Modifies | Consumed By | Integration Test |
+|------|-----------------|-------------|-----------------|
+| TASK-001 | `zerg/data/tones/educational.md` | TASK-004 | tests/unit/test_document_tone.py |
+| TASK-002 | `zerg/data/tones/reference.md` | TASK-004 | tests/unit/test_document_tone.py |
+| TASK-003 | `zerg/data/tones/tutorial.md` | TASK-004 | tests/unit/test_document_tone.py |
+| TASK-004 | `zerg/commands/document.py`, `document.md` | TASK-008 | tests/unit/test_document_tone.py |
+| TASK-005 | `plan.core.md`, `plan.md` | leaf (prompt) | — |
+| TASK-006 | `plan.details.md` | leaf (prompt) | — |
+| TASK-007 | `design.core.md`, `design.md` | leaf (prompt) | — |
+| TASK-008 | `tests/unit/test_document_tone.py` | leaf (test) | — |
+| TASK-009 | CHANGELOG, README, docs/* | leaf (docs) | — |
+| TASK-010 | wiki/*, CLAUDE.md | leaf (docs) | — |
+| TASK-011 | (none — verification only) | leaf | — |
+
+---
+
+## 10. Approval
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|
+| Architecture | | | PENDING |
+| Engineering | | | PENDING |

--- a/.gsd/specs/github-issues-129-163-165/requirements.md
+++ b/.gsd/specs/github-issues-129-163-165/requirements.md
@@ -1,0 +1,191 @@
+# Feature Requirements: GitHub Issues #129, #163, #165
+
+## Metadata
+- **Feature**: github-issues-129-163-165
+- **Status**: APPROVED
+- **Created**: 2026-02-07
+- **Author**: Factory Plan Mode (Socratic)
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Background
+Three related issues affect ZERG's documentation and workflow quality:
+- Issue #129: `/zerg:document` produces only terse reference docs. An educational tone was manually developed but must be applied by hand.
+- Issue #163: `/z:plan` occasionally bypasses the plan->design->rush workflow and auto-implements, violating the strict phase boundaries.
+- Issue #165: Neither `/z:plan` nor `/z:design` systematically track documentation impact, leading to features shipping without updated docs.
+
+### 1.2 Problem
+1. No automated way to generate educational-style documentation from `/zerg:document`
+2. Plan command lacks sufficient prompt-level guards against auto-implementation drift
+3. Documentation drift: features ship without CHANGELOG, README, wiki, or command reference updates
+
+### 1.3 Impact
+- New users struggle with terse reference docs (no concept explanations, no diagrams)
+- Workflow violations waste time and break the plan->design->rush contract
+- Stale documentation erodes trust and creates confusion
+
+---
+
+## 2. Users
+
+### 2.1 Primary Users
+- Developers using ZERG to parallelize Claude Code work
+- Contributors modifying ZERG commands
+
+### 2.2 User Stories
+- As a developer, I want `/zerg:document --tone educational` to auto-generate concept-first documentation so I don't have to manually rewrite reference docs
+- As a user, I want `/z:plan` to never start implementing so the plan->design->rush workflow is respected
+- As a contributor, I want `/z:plan` and `/z:design` to surface documentation impacts so docs stay current
+
+---
+
+## 3. Functional Requirements
+
+### 3.1 Core Capabilities
+
+| ID | Requirement | Priority | Issue |
+|----|-------------|----------|-------|
+| FR-001 | Add `--tone educational\|reference\|tutorial` flag to `/zerg:document` | Must | #129 |
+| FR-002 | `educational` is the DEFAULT tone (not reference) | Must | #129 |
+| FR-003 | Tone definitions stored as separate files at `zerg/data/tones/{tone}.md` | Must | #129 |
+| FR-004 | Educational tone: every concept has CONCEPT, NARRATIVE, DIAGRAM, COMMAND sections | Must | #129 |
+| FR-005 | Reference tone: terse tables and API signatures (current behavior) | Must | #129 |
+| FR-006 | Tutorial tone: step-by-step walkthrough with simulated dialogues | Must | #129 |
+| FR-007 | Add redundant anti-implementation guards to `plan.core.md` at 4 locations | Must | #163 |
+| FR-008 | Plan terminal output: "PLANNING COMPLETE" banner with explicit EXIT statement | Must | #163 |
+| FR-009 | Add Section 11 "Documentation Impact Analysis" to plan's requirements.md template | Must | #165 |
+| FR-010 | Design command always generates CHANGELOG.md task in Level 5 quality phase | Must | #165 |
+| FR-011 | Design command generates doc update tasks whenever command/flag functionality changes | Must | #165 |
+| FR-012 | Update project documentation (README, wiki, command refs, CLAUDE.md) for this feature | Must | #165 |
+
+### 3.2 Inputs
+- `--tone` flag value: `educational` (default), `reference`, `tutorial`
+- Tone definition files: `zerg/data/tones/{tone}.md`
+
+### 3.3 Outputs
+- Documentation generated in the specified tone style
+- Plan requirements.md with Section 11 documentation impact analysis
+- Design task-graph.json with mandatory doc/CHANGELOG tasks
+- Updated project documentation reflecting all changes
+
+---
+
+## 4. Non-Functional Requirements
+
+### 4.1 Performance
+- No performance impact — tone is a prompt-level directive, not a computational change
+
+### 4.2 Maintainability
+- Tone definitions as separate files: adding a new tone = adding a file (no editing existing commands)
+- `document.md` stays under 300-line split threshold
+
+### 4.3 Testing
+- Unit tests for `--tone` flag parsing in `document.py`
+- CI drift check via `validate_commands` for plan anti-implementation guards
+- Verification commands for each task in the task graph
+
+---
+
+## 5. Scope
+
+### 5.1 In Scope
+- `--tone` flag for `/zerg:document` with 3 tones
+- 3 tone definition files (`educational.md`, `reference.md`, `tutorial.md`)
+- Anti-implementation hardening of `plan.core.md` and `plan.md` (prompt-level only)
+- Section 11 in plan's requirements.md template
+- Mandatory doc task generation in design command
+- Project documentation updates (README, wiki, command refs, CLAUDE.md)
+- CHANGELOG.md entries
+
+### 5.2 Out of Scope
+- Python-level enforcement of plan workflow boundaries (deferred)
+- Tone content transformation engine (tone is prompt-level, not programmatic)
+- Splitting `document.md` into core/details (stays under 300 lines)
+
+### 5.3 Assumptions
+- `/zerg:document` is a Claude Code slash command where Claude has file access to read tone files
+- Parent files (`plan.md`, `design.md`) must stay synchronized with their `.core.md` counterparts
+
+---
+
+## 6. Dependencies
+
+### 6.1 Internal Dependencies
+| Dependency | Type | Status |
+|------------|------|--------|
+| `zerg/commands/document.py` | Modify | Exists |
+| `zerg/data/commands/document.md` | Modify | Exists |
+| `zerg/data/commands/plan.core.md` | Modify | Exists |
+| `zerg/data/commands/plan.details.md` | Modify | Exists |
+| `zerg/data/commands/design.core.md` | Modify | Exists |
+| `.gsd/specs/documentation-tone-overhaul/requirements.md` | Reference | Approved |
+
+---
+
+## 7. Acceptance Criteria
+
+### 7.1 Definition of Done
+- [ ] `--tone` flag accepted by `/zerg:document` with educational as default
+- [ ] 3 tone definition files exist at `zerg/data/tones/`
+- [ ] `plan.core.md` has anti-implementation guards at 4+ locations
+- [ ] Plan terminal output shows "PLANNING COMPLETE" banner
+- [ ] `plan.details.md` requirements template includes Section 11
+- [ ] `design.core.md` has "Mandatory Documentation Tasks" subsection
+- [ ] All unit tests pass
+- [ ] `validate_commands` passes
+- [ ] Project docs (README, wiki, command refs, CLAUDE.md) updated
+- [ ] CHANGELOG.md updated
+
+### 7.2 Test Scenarios
+
+| ID | Scenario | Given | When | Then |
+|----|----------|-------|------|------|
+| TC-001 | Default tone | No --tone flag | Run /zerg:document | Educational tone used |
+| TC-002 | Explicit reference | --tone reference | Run /zerg:document | Reference style output |
+| TC-003 | Invalid tone | --tone bogus | Run /zerg:document | Click rejects with error |
+| TC-004 | Plan guards | Run /z:plan | Requirements approved | No implementation occurs; "PLANNING COMPLETE" shown |
+| TC-005 | Design doc tasks | Run /z:design | Task graph generated | CHANGELOG task present in Level 5 |
+
+---
+
+## 8. Open Questions
+
+None — all resolved through Socratic discovery rounds.
+
+---
+
+## 9. Approval
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|
+| Engineering | User | 2026-02-07 | APPROVED |
+
+---
+
+## 10. Documentation
+
+After implementation, execute `/zerg:document` to update all documentation surfaces.
+
+---
+
+## 11. Documentation Impact Analysis
+
+### 11.1 Files Requiring Documentation Updates
+| File | Current State | Required Update | Priority |
+|------|--------------|-----------------|----------|
+| `CHANGELOG.md` | [Unreleased] section | Add entries for --tone flag, plan guards, doc impact analysis | Must |
+| `README.md` | Shows `/zerg:document` without --tone | Add --tone flag to usage examples | Must |
+| `docs/commands-quick.md` | Document flag table lacks --tone | Add --tone row | Must |
+| `docs/commands-deep.md` | No tone documentation | Add --tone deep docs with tone descriptions | Must |
+| `.gsd/wiki/Command-Reference.md` | Document entry lacks --tone | Update with --tone flag | Must |
+| `.gsd/wiki/Tutorial.md` | Document examples lack tone | Update examples to mention tone | Should |
+| `CLAUDE.md` | No doc impact analysis requirement | Document the new requirement for /z:plan and /z:design | Must |
+
+### 11.2 Documentation Tasks for Design Phase
+- [x] CHANGELOG.md update task (ALWAYS required)
+- [x] README.md update (new CLI flag)
+- [x] Command reference updates (command/flag functionality changed)
+- [x] CLAUDE.md update (new project convention)
+- [x] Wiki updates (user-facing behavior changes)

--- a/.gsd/specs/github-issues-129-163-165/task-graph.json
+++ b/.gsd/specs/github-issues-129-163-165/task-graph.json
@@ -1,0 +1,365 @@
+{
+  "feature": "github-issues-129-163-165",
+  "version": "2.0",
+  "generated": "2026-02-07T00:00:00Z",
+  "total_tasks": 11,
+  "estimated_duration_minutes": 80,
+  "max_parallelization": 3,
+
+  "tasks": [
+    {
+      "id": "TASK-001",
+      "title": "Create educational tone definition",
+      "description": "Create zerg/data/tones/educational.md defining the educational documentation tone. Must include: tone name/description, required sections per concept (CONCEPT, NARRATIVE, DIAGRAM, COMMAND), output structure template, and example output. This is the DEFAULT tone for /zerg:document.",
+      "phase": "foundation",
+      "level": 1,
+      "dependencies": [],
+      "files": {
+        "create": ["zerg/data/tones/educational.md"],
+        "modify": [],
+        "read": ["zerg/data/commands/document.md"]
+      },
+      "acceptance_criteria": [
+        "File exists at zerg/data/tones/educational.md",
+        "Contains CONCEPT, NARRATIVE, DIAGRAM, COMMAND section definitions",
+        "Includes example output demonstrating the tone",
+        "Explains when to use this tone"
+      ],
+      "verification": {
+        "command": "test -f zerg/data/tones/educational.md && grep -q 'CONCEPT' zerg/data/tones/educational.md && grep -q 'NARRATIVE' zerg/data/tones/educational.md",
+        "timeout_seconds": 30
+      },
+      "estimate_minutes": 15,
+      "skills_required": ["documentation"],
+      "consumers": ["TASK-004"],
+      "integration_test": "tests/unit/test_document_tone.py",
+      "context": "## Spec Context\nFR-001: Add --tone educational|reference|tutorial flag to /zerg:document\nFR-002: educational is the DEFAULT tone (not reference)\nFR-004: Educational tone: every concept has CONCEPT, NARRATIVE, DIAGRAM, COMMAND sections\n\nThe educational tone was manually developed for issue #129. It teaches 'why' not just 'what'. Every concept gets a plain-language explanation, a narrative connecting it to the bigger picture, a Mermaid diagram, and concrete CLI examples.\n\n## Dependencies\nNo upstream dependencies — this is a foundation task."
+    },
+    {
+      "id": "TASK-002",
+      "title": "Create reference tone definition",
+      "description": "Create zerg/data/tones/reference.md defining the reference documentation tone. This preserves the current terse documentation behavior: tables, API signatures, parameter lists, minimal prose.",
+      "phase": "foundation",
+      "level": 1,
+      "dependencies": [],
+      "files": {
+        "create": ["zerg/data/tones/reference.md"],
+        "modify": [],
+        "read": ["zerg/data/commands/document.md"]
+      },
+      "acceptance_criteria": [
+        "File exists at zerg/data/tones/reference.md",
+        "Defines terse table-driven output style",
+        "Includes example output demonstrating the tone",
+        "Matches current /zerg:document default behavior"
+      ],
+      "verification": {
+        "command": "test -f zerg/data/tones/reference.md && grep -qi 'reference' zerg/data/tones/reference.md",
+        "timeout_seconds": 30
+      },
+      "estimate_minutes": 10,
+      "skills_required": ["documentation"],
+      "consumers": ["TASK-004"],
+      "integration_test": "tests/unit/test_document_tone.py",
+      "context": "## Spec Context\nFR-005: Reference tone: terse tables and API signatures (current behavior)\n\nThe reference tone preserves backward compatibility with current /zerg:document output. It's the 'just the facts' style — parameter tables, return types, function signatures. No narrative, no diagrams unless structurally necessary.\n\n## Dependencies\nNo upstream dependencies — this is a foundation task."
+    },
+    {
+      "id": "TASK-003",
+      "title": "Create tutorial tone definition",
+      "description": "Create zerg/data/tones/tutorial.md defining the tutorial documentation tone. Step-by-step walkthrough style with simulated dialogues and progressive complexity.",
+      "phase": "foundation",
+      "level": 1,
+      "dependencies": [],
+      "files": {
+        "create": ["zerg/data/tones/tutorial.md"],
+        "modify": [],
+        "read": ["zerg/data/commands/document.md"]
+      },
+      "acceptance_criteria": [
+        "File exists at zerg/data/tones/tutorial.md",
+        "Defines step-by-step walkthrough style",
+        "Includes simulated dialogue examples",
+        "Shows progressive complexity structure"
+      ],
+      "verification": {
+        "command": "test -f zerg/data/tones/tutorial.md && grep -qi 'tutorial' zerg/data/tones/tutorial.md",
+        "timeout_seconds": 30
+      },
+      "estimate_minutes": 10,
+      "skills_required": ["documentation"],
+      "consumers": ["TASK-004"],
+      "integration_test": "tests/unit/test_document_tone.py",
+      "context": "## Spec Context\nFR-006: Tutorial tone: step-by-step walkthrough with simulated dialogues\n\nThe tutorial tone generates documentation as a guided walkthrough. Each concept is introduced progressively, building on previous steps. Includes simulated terminal sessions showing what the user types and what they see.\n\n## Dependencies\nNo upstream dependencies — this is a foundation task."
+    },
+    {
+      "id": "TASK-004",
+      "title": "Add --tone flag to /zerg:document",
+      "description": "Modify zerg/commands/document.py to add --tone click option (educational|reference|tutorial, default educational). Modify zerg/data/commands/document.md prompt to instruct Claude to read the appropriate tone file from zerg/data/tones/{tone}.md and apply its style.",
+      "phase": "core",
+      "level": 2,
+      "dependencies": ["TASK-001", "TASK-002", "TASK-003"],
+      "files": {
+        "create": [],
+        "modify": ["zerg/commands/document.py", "zerg/data/commands/document.md"],
+        "read": ["zerg/data/tones/educational.md", "zerg/data/tones/reference.md", "zerg/data/tones/tutorial.md"]
+      },
+      "acceptance_criteria": [
+        "--tone flag accepted by Click with choices educational|reference|tutorial",
+        "Default tone is educational",
+        "Tone value passed through to renderer/prompt layer",
+        "document.md instructs Claude to read zerg/data/tones/{tone}.md",
+        "Help text updated to show --tone flag",
+        "document.md stays under 300 lines"
+      ],
+      "verification": {
+        "command": "cd /Users/klambros/PycharmProjects/ZERG && python -c \"from zerg.commands.document import document; print('OK')\" && grep -q 'tone' zerg/commands/document.py && grep -q 'tone' zerg/data/commands/document.md",
+        "timeout_seconds": 60
+      },
+      "estimate_minutes": 20,
+      "skills_required": ["python", "click"],
+      "consumers": ["TASK-008"],
+      "integration_test": "tests/unit/test_document_tone.py",
+      "context": "## Security Rules (Python)\n- Use click.Choice for input validation (already standard pattern)\n- No user-controlled file paths — tone maps to a fixed set of files\n\n## Spec Context\nFR-001: Add --tone educational|reference|tutorial flag\nFR-002: educational is DEFAULT\nFR-003: Tone definitions stored at zerg/data/tones/{tone}.md\n\nExisting document.py has @click.option for --type, --output, --depth, --update. Add --tone in the same pattern. The prompt file (document.md) must instruct Claude to read the tone file and follow its style guidelines.\n\n## Dependencies\nTASK-001/002/003 create the tone definition files at zerg/data/tones/."
+    },
+    {
+      "id": "TASK-005",
+      "title": "Harden plan command anti-implementation guards",
+      "description": "Add redundant anti-implementation guards to plan.core.md at 4 locations: (1) strengthen existing top-of-file banner, (2) new guard before Phase 2, (3) new guard before Phase 5, (4) strengthen post-approval section with PLANNING COMPLETE terminal banner. Sync identical changes to plan.md parent file.",
+      "phase": "core",
+      "level": 2,
+      "dependencies": [],
+      "files": {
+        "create": [],
+        "modify": ["zerg/data/commands/plan.core.md", "zerg/data/commands/plan.md"],
+        "read": []
+      },
+      "acceptance_criteria": [
+        "plan.core.md has anti-implementation guards at 4+ locations",
+        "Each guard contains 'MUST NEVER' or equivalent strong language",
+        "Post-approval section shows PLANNING COMPLETE terminal banner",
+        "Banner includes explicit EXIT statement",
+        "plan.md parent file synced with core changes",
+        "TaskCreate/TaskUpdate references preserved (no drift)"
+      ],
+      "verification": {
+        "command": "count=$(grep -c 'MUST NEVER\\|DO NOT.*implement\\|DO NOT.*write code\\|DO NOT.*design' zerg/data/commands/plan.core.md); test $count -ge 4 && echo \"OK: $count guards\" || echo \"FAIL: only $count guards\"",
+        "timeout_seconds": 30
+      },
+      "estimate_minutes": 15,
+      "skills_required": ["prompt-engineering"],
+      "consumers": [],
+      "integration_test": null,
+      "context": "## Spec Context\nFR-007: Add redundant anti-implementation guards to plan.core.md at 4 locations\nFR-008: Plan terminal output: 'PLANNING COMPLETE' banner with explicit EXIT statement\n\nIssue #163: /z:plan occasionally bypasses the plan->design->rush workflow and auto-implements. The existing guard at top-of-file is insufficient because Claude forgets it by Phase 5. Redundant guards at decision boundaries prevent drift.\n\nCurrent plan.core.md already has one guard section at the top. Add 3 more at strategic locations. The parent plan.md must stay synced.\n\n## Anti-Drift\nplan.core.md and plan.md both contain TaskCreate/TaskUpdate references. These are load-bearing — DO NOT remove them."
+    },
+    {
+      "id": "TASK-006",
+      "title": "Add Section 11 Documentation Impact Analysis to plan template",
+      "description": "Add Section 11 'Documentation Impact Analysis' to the requirements.md template in plan.details.md. This section appears after Section 10 and includes a file impact table and a documentation tasks checklist for the design phase.",
+      "phase": "core",
+      "level": 2,
+      "dependencies": [],
+      "files": {
+        "create": [],
+        "modify": ["zerg/data/commands/plan.details.md"],
+        "read": []
+      },
+      "acceptance_criteria": [
+        "plan.details.md requirements template includes Section 11",
+        "Section 11 has subsections: 11.1 Files Requiring Documentation Updates, 11.2 Documentation Tasks for Design Phase",
+        "11.1 contains a table template with File, Current State, Required Update, Priority columns",
+        "11.2 contains a checklist including CHANGELOG (always required), README, command refs, CLAUDE.md, wiki"
+      ],
+      "verification": {
+        "command": "grep -q 'Documentation Impact Analysis' zerg/data/commands/plan.details.md && grep -q '11.1' zerg/data/commands/plan.details.md && grep -q '11.2' zerg/data/commands/plan.details.md",
+        "timeout_seconds": 30
+      },
+      "estimate_minutes": 10,
+      "skills_required": ["documentation"],
+      "consumers": [],
+      "integration_test": null,
+      "context": "## Spec Context\nFR-009: Add Section 11 'Documentation Impact Analysis' to plan's requirements.md template\n\nIssue #165: Neither /z:plan nor /z:design systematically track documentation impact. Section 11 is added to the requirements template so every feature plan explicitly identifies which docs need updating.\n\nThe template in plan.details.md currently ends at Section 10 (Documentation). Section 11 goes after it, inside the template markdown code block."
+    },
+    {
+      "id": "TASK-007",
+      "title": "Add mandatory documentation tasks to design command",
+      "description": "Modify design.core.md to include a 'Mandatory Documentation Tasks' subsection in the Phase 2 implementation plan. This subsection requires: (1) CHANGELOG.md task ALWAYS in Level 5 quality phase, (2) doc update tasks whenever command/flag functionality changes. Sync changes to design.md parent file.",
+      "phase": "core",
+      "level": 2,
+      "dependencies": [],
+      "files": {
+        "create": [],
+        "modify": ["zerg/data/commands/design.core.md", "zerg/data/commands/design.md"],
+        "read": []
+      },
+      "acceptance_criteria": [
+        "design.core.md has 'Mandatory Documentation Tasks' subsection",
+        "CHANGELOG.md task required in every task graph Level 5",
+        "Doc update tasks required when command/flag behavior changes",
+        "design.md parent file synced with core changes",
+        "Completion criteria updated to include doc task requirement",
+        "TaskCreate/TaskUpdate references preserved (no drift)"
+      ],
+      "verification": {
+        "command": "grep -q 'Mandatory Documentation Tasks' zerg/data/commands/design.core.md && grep -q 'CHANGELOG' zerg/data/commands/design.core.md",
+        "timeout_seconds": 30
+      },
+      "estimate_minutes": 15,
+      "skills_required": ["prompt-engineering"],
+      "consumers": [],
+      "integration_test": null,
+      "context": "## Spec Context\nFR-010: Design command always generates CHANGELOG.md task in Level 5 quality phase\nFR-011: Design command generates doc update tasks whenever command/flag functionality changes\n\nIssue #165: Features ship without updated docs. The design command must enforce documentation tasks in every task graph. design.core.md already mentions CHANGELOG in Phase 5 example but doesn't mandate it. Make it a hard requirement.\n\n## Anti-Drift\ndesign.core.md and design.md contain TaskCreate/TaskUpdate references. These are load-bearing — DO NOT remove them."
+    },
+    {
+      "id": "TASK-008",
+      "title": "Create unit tests for --tone flag",
+      "description": "Create tests/unit/test_document_tone.py with tests for: (1) default tone is educational, (2) explicit --tone reference works, (3) explicit --tone tutorial works, (4) invalid --tone value rejected, (5) tone definition files exist at expected paths. Uses Click CliRunner with mocked doc_engine dependencies.",
+      "phase": "testing",
+      "level": 3,
+      "dependencies": ["TASK-004", "TASK-005", "TASK-006", "TASK-007"],
+      "files": {
+        "create": ["tests/unit/test_document_tone.py"],
+        "modify": [],
+        "read": ["zerg/commands/document.py", "tests/unit/test_wiki_document.py"]
+      },
+      "acceptance_criteria": [
+        "Test file exists at tests/unit/test_document_tone.py",
+        "Tests cover: default tone, explicit tones, invalid tone, tone file existence",
+        "All tests pass with mocked doc_engine",
+        "Follows existing test patterns from test_wiki_document.py"
+      ],
+      "verification": {
+        "command": "cd /Users/klambros/PycharmProjects/ZERG && python -m pytest tests/unit/test_document_tone.py -x -q --timeout=60",
+        "timeout_seconds": 120
+      },
+      "estimate_minutes": 15,
+      "skills_required": ["python", "pytest", "click-testing"],
+      "consumers": [],
+      "integration_test": null,
+      "context": "## Security Rules (Python)\n- No dangerous deserialization\n- Use subprocess safely if needed\n\n## Spec Context\nTC-001: Default tone — No --tone flag → Educational tone used\nTC-002: Explicit reference — --tone reference → Reference style output\nTC-003: Invalid tone — --tone bogus → Click rejects with error\n\nExisting test patterns in test_wiki_document.py use Click CliRunner with mocked doc_engine imports. Follow the same _make_mock_doc_engine() helper pattern.\n\n## Dependencies\nTASK-004 modifies document.py to add --tone flag. Tests must verify the flag is parsed correctly and passed through."
+    },
+    {
+      "id": "TASK-009",
+      "title": "Update project docs: CHANGELOG, README, command refs",
+      "description": "Update CHANGELOG.md [Unreleased] section with entries for --tone flag, plan guards, and doc impact analysis. Update README.md to show --tone flag in usage examples. Update docs/commands-quick.md and docs/commands-deep.md with --tone row in document flag table.",
+      "phase": "quality",
+      "level": 4,
+      "dependencies": ["TASK-008"],
+      "files": {
+        "create": [],
+        "modify": ["CHANGELOG.md", "README.md", "docs/commands-quick.md", "docs/commands-deep.md"],
+        "read": []
+      },
+      "acceptance_criteria": [
+        "CHANGELOG.md has entries under [Unreleased] for all 3 issues",
+        "README.md shows --tone flag in /zerg:document examples",
+        "docs/commands-quick.md has --tone row in document flag table",
+        "docs/commands-deep.md has --tone documentation"
+      ],
+      "verification": {
+        "command": "grep -q 'tone' CHANGELOG.md && grep -q 'tone' docs/commands-quick.md",
+        "timeout_seconds": 30
+      },
+      "estimate_minutes": 15,
+      "skills_required": ["documentation"],
+      "consumers": [],
+      "integration_test": null,
+      "context": "## Spec Context\nFR-012: Update project documentation (README, wiki, command refs, CLAUDE.md) for this feature\n\nCHANGELOG entries needed:\n- Added: --tone flag for /zerg:document with educational (default), reference, tutorial tones\n- Added: 3 tone definition files at zerg/data/tones/\n- Changed: /z:plan anti-implementation guards hardened at 4 locations\n- Changed: Plan requirements template includes Section 11 Documentation Impact Analysis\n- Changed: /z:design mandates CHANGELOG and doc tasks in task graphs"
+    },
+    {
+      "id": "TASK-010",
+      "title": "Update wiki and CLAUDE.md",
+      "description": "Update .gsd/wiki/Command-Reference.md with --tone flag for /zerg:document. Update .gsd/wiki/Tutorial.md with tone examples. Update CLAUDE.md to document the new documentation impact analysis requirement for /z:plan and /z:design.",
+      "phase": "quality",
+      "level": 4,
+      "dependencies": ["TASK-008"],
+      "files": {
+        "create": [],
+        "modify": [".gsd/wiki/Command-Reference.md", ".gsd/wiki/Tutorial.md", "CLAUDE.md"],
+        "read": []
+      },
+      "acceptance_criteria": [
+        "Command-Reference.md shows --tone flag for /zerg:document",
+        "Tutorial.md mentions tone in documentation examples",
+        "CLAUDE.md documents documentation impact analysis requirement"
+      ],
+      "verification": {
+        "command": "grep -q 'tone' .gsd/wiki/Command-Reference.md && grep -q 'tone' .gsd/wiki/Tutorial.md",
+        "timeout_seconds": 30
+      },
+      "estimate_minutes": 15,
+      "skills_required": ["documentation"],
+      "consumers": [],
+      "integration_test": null,
+      "context": "## Spec Context\nFR-012: Update project documentation for this feature\n\nCommand-Reference.md is a large wiki page (~28K tokens). Find the /zerg:document section and add --tone to its flag table. Tutorial.md should mention tone selection in its documentation examples. CLAUDE.md needs a note about the new convention that /z:plan and /z:design track documentation impact."
+    },
+    {
+      "id": "TASK-011",
+      "title": "Run wiring verification",
+      "description": "Verify all new modules have production callers and imports resolve. Run validate_commands for structural checks, then scoped pytest for new + affected tests.",
+      "phase": "quality",
+      "level": 5,
+      "dependencies": ["TASK-009", "TASK-010"],
+      "files": {
+        "create": [],
+        "modify": [],
+        "read": ["zerg/**/*.py", "tests/**/*.py"]
+      },
+      "acceptance_criteria": [
+        "validate_commands passes",
+        "All new and affected tests pass",
+        "No drift detected in command files"
+      ],
+      "verification": {
+        "command": "cd /Users/klambros/PycharmProjects/ZERG && python -m zerg.validate_commands && python -m pytest tests/unit/test_document_tone.py tests/unit/test_wiki_document.py -x --timeout=60 -q",
+        "timeout_seconds": 120
+      },
+      "estimate_minutes": 5,
+      "skills_required": [],
+      "consumers": [],
+      "integration_test": null,
+      "context": "## Verification\nFinal quality gate. Runs validate_commands to check command file integrity and drift detection, then runs scoped pytest on new and affected test files."
+    }
+  ],
+
+  "levels": {
+    "1": {
+      "name": "foundation",
+      "tasks": ["TASK-001", "TASK-002", "TASK-003"],
+      "parallel": true,
+      "estimated_minutes": 15
+    },
+    "2": {
+      "name": "core",
+      "tasks": ["TASK-004", "TASK-005", "TASK-006", "TASK-007"],
+      "parallel": true,
+      "estimated_minutes": 20,
+      "depends_on_levels": [1]
+    },
+    "3": {
+      "name": "testing",
+      "tasks": ["TASK-008"],
+      "parallel": false,
+      "estimated_minutes": 15,
+      "depends_on_levels": [2]
+    },
+    "4": {
+      "name": "documentation",
+      "tasks": ["TASK-009", "TASK-010"],
+      "parallel": true,
+      "estimated_minutes": 15,
+      "depends_on_levels": [3]
+    },
+    "5": {
+      "name": "quality-wiring",
+      "tasks": ["TASK-011"],
+      "parallel": false,
+      "estimated_minutes": 5,
+      "depends_on_levels": [4]
+    }
+  },
+
+  "conflict_matrix": {
+    "description": "Tasks that cannot run in parallel due to shared files",
+    "conflicts": []
+  }
+}

--- a/.gsd/wiki/Command-Reference.md
+++ b/.gsd/wiki/Command-Reference.md
@@ -2852,6 +2852,7 @@ Preserves manual edits outside auto-generated sections.
 | `--output` | string | stdout | Output path |
 | `--depth` | string | standard | Depth: `shallow`, `standard`, `deep` |
 | `--update` | boolean | false | Update existing docs |
+| `--tone` | `educational\|reference\|tutorial` | `educational` | Documentation tone — controls output style |
 
 ---
 

--- a/.gsd/wiki/Tutorial.md
+++ b/.gsd/wiki/Tutorial.md
@@ -847,6 +847,21 @@ Use `--dry-run` to preview what would be removed.
 
 ---
 
+## Documentation Tones
+
+The `/zerg:document` command supports three documentation tones via the `--tone` flag:
+
+- **educational** (default): Concept-first documentation with CONCEPT, NARRATIVE, DIAGRAM, and COMMAND sections for every concept
+- **reference**: Terse tables and API signatures for quick lookup
+- **tutorial**: Step-by-step walkthrough with simulated terminal dialogues
+
+Example:
+```
+/zerg:document zerg/launcher.py --tone reference
+```
+
+---
+
 ## Quick Reference
 
 ### Phase Summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `--tone` flag for `/zerg:document` with `educational` (default), `reference`, and `tutorial` tones for documentation style control
+- 3 tone definition files at `zerg/data/tones/` (`educational.md`, `reference.md`, `tutorial.md`) for documentation style guidance
 - `--admin` flag for `/zerg:git --action ship`: use admin merge directly, bypassing branch protection rules (repo owner/admin)
 - `zerg/state/` package: decompose 1010-line StateManager into 9 focused modules with facade pattern
 - `zerg/fs_utils.py`: single-pass file traversal utility replacing scattered rglob calls
@@ -30,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `/z:plan` anti-implementation guards hardened at 4 locations with PLANNING COMPLETE terminal banner
+- Plan requirements template includes Section 11 "Documentation Impact Analysis"
+- `/z:design` mandates CHANGELOG and documentation update tasks in every task graph
 - Enable BLE001 ruff rule (bare-except detection) in pyproject.toml
 - Migrated 14 production files from `import json` to `zerg.json_utils`
 - `--skip-validation` flag for `/z:plan` and `/z:design` to bypass Phase 0 pre-execution validation checks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,10 @@ Use `/zerg:status` to view the CONTEXT BUDGET section showing:
 - Per-task context population rate
 - Security rule filtering stats
 
+## Documentation Impact Analysis
+
+The `/z:plan` command now includes Section 11 "Documentation Impact Analysis" in its requirements template. This ensures every feature plan explicitly identifies which docs need updating. The `/z:design` command mandates CHANGELOG.md and documentation update tasks in every task graph.
+
 ## PR Documentation Rules
 
 When creating a pull request, **always update CHANGELOG.md** under the `[Unreleased]` section with a brief entry describing the change. Use the appropriate category:

--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ Other git operations available:
 
 | Command | Purpose |
 |---------|---------|
-| `/zerg:document` | Generate component documentation |
+| `/zerg:document` | Generate component documentation (`--tone educational\|reference\|tutorial`) |
 | `/zerg:index` | Generate project documentation wiki |
 | `/zerg:estimate` | Effort estimation with PERT intervals |
 | `/zerg:explain` | Educational code explanations |

--- a/docs/commands-deep.md
+++ b/docs/commands-deep.md
@@ -2559,6 +2559,11 @@ The depth levels let you control how much detail is included - shallow for quick
 - `standard` - Adds internal methods, imports, basic diagrams
 - `deep` - All methods, usage examples, full dependency graph
 
+**Tone options** (`--tone`):
+- `educational` (default) - Concept-first documentation that explains *why* before *how*. Includes context, analogies, and background. Best for onboarding and learning.
+- `reference` - Terse, scannable API reference. Minimal prose, maximum density. Focuses on signatures, parameters, return types, and examples. Best for experienced developers who need quick lookups.
+- `tutorial` - Step-by-step walkthrough with numbered instructions. Assumes minimal prior knowledge. Includes prerequisites, expected output, and troubleshooting tips. Best for guides and how-to content.
+
 #### Using It
 
 **Document a module:**
@@ -2596,6 +2601,13 @@ graph TD
     launcher --> subprocess
     launcher --> task_system
 ```
+```
+
+**With tone control:**
+```
+/zerg:document zerg/launcher.py --tone educational   # Concept-first docs (default)
+/zerg:document zerg/launcher.py --tone reference     # Terse API reference
+/zerg:document zerg/launcher.py --tone tutorial       # Step-by-step walkthrough
 ```
 
 **Deep documentation to file:**

--- a/docs/commands-quick.md
+++ b/docs/commands-quick.md
@@ -374,6 +374,7 @@ Generate documentation for a single component.
 | `--type` | string | auto | Type: `auto`, `module`, `command`, `config`, `api`, `types` |
 | `--output` | string | stdout | Output path |
 | `--depth` | string | standard | Depth: `shallow`, `standard`, `deep` |
+| `--tone` | string | `educational` | Documentation tone: `educational`, `reference`, `tutorial` |
 | `--update` | bool | false | Update in-place |
 
 ### /zerg:estimate

--- a/tests/unit/test_document_tone.py
+++ b/tests/unit/test_document_tone.py
@@ -1,0 +1,121 @@
+"""Tests for the --tone flag on zerg/commands/document.py.
+
+Covers: default tone, explicit tones, invalid tone, and tone file existence.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+
+def _make_mock_doc_engine():
+    """Return a dict of mock classes for all doc_engine imports."""
+    mock_detector = MagicMock()
+    mock_extractor = MagicMock()
+    mock_mapper = MagicMock()
+    mock_mermaid = MagicMock()
+    mock_renderer = MagicMock()
+    mock_crossref = MagicMock()
+
+    mock_renderer_inst = mock_renderer.return_value
+    mock_renderer_inst.render.return_value = "# Mock Docs"
+
+    mock_extractor_inst = mock_extractor.return_value
+    mock_extractor_inst.extract.return_value = MagicMock(
+        classes=[MagicMock()],
+        functions=[MagicMock()],
+    )
+
+    return {
+        "ComponentDetector": mock_detector,
+        "SymbolExtractor": mock_extractor,
+        "DependencyMapper": mock_mapper,
+        "MermaidGenerator": mock_mermaid,
+        "DocRenderer": mock_renderer,
+        "CrossRefBuilder": mock_crossref,
+    }
+
+
+class TestDocumentTone:
+    """Tests for the --tone flag on the document command."""
+
+    @pytest.fixture()
+    def runner(self):
+        return CliRunner()
+
+    @pytest.fixture()
+    def mocks(self):
+        return _make_mock_doc_engine()
+
+    def _invoke(self, runner, mocks, tmp_path, extra_args=None):
+        """Helper to invoke the document command with mocked doc_engine."""
+        from zerg.commands.document import document
+
+        target = tmp_path / "module.py"
+        target.write_text("# module code\ndef hello(): pass")
+
+        from zerg.doc_engine.detector import ComponentType
+
+        detector_inst = mocks["ComponentDetector"].return_value
+        detector_inst.detect.return_value = ComponentType.MODULE
+
+        args = [str(target)]
+        if extra_args:
+            args.extend(extra_args)
+
+        with (
+            patch("zerg.doc_engine.crossref.CrossRefBuilder", mocks["CrossRefBuilder"]),
+            patch("zerg.doc_engine.dependencies.DependencyMapper", mocks["DependencyMapper"]),
+            patch("zerg.doc_engine.detector.ComponentDetector", mocks["ComponentDetector"]),
+            patch("zerg.doc_engine.extractor.SymbolExtractor", mocks["SymbolExtractor"]),
+            patch("zerg.doc_engine.mermaid.MermaidGenerator", mocks["MermaidGenerator"]),
+            patch("zerg.doc_engine.renderer.DocRenderer", mocks["DocRenderer"]),
+        ):
+            result = runner.invoke(document, args, catch_exceptions=False)
+
+        return result
+
+    def test_default_tone_is_educational(self, runner, mocks, tmp_path):
+        """Without --tone flag, the default tone is educational."""
+        result = self._invoke(runner, mocks, tmp_path)
+        assert result.exit_code == 0
+        assert "Tone:" in result.output
+        assert "educational" in result.output
+
+    def test_explicit_tone_reference(self, runner, mocks, tmp_path):
+        """--tone reference is accepted and displayed."""
+        result = self._invoke(runner, mocks, tmp_path, ["--tone", "reference"])
+        assert result.exit_code == 0
+        assert "reference" in result.output
+
+    def test_explicit_tone_tutorial(self, runner, mocks, tmp_path):
+        """--tone tutorial is accepted and displayed."""
+        result = self._invoke(runner, mocks, tmp_path, ["--tone", "tutorial"])
+        assert result.exit_code == 0
+        assert "tutorial" in result.output
+
+    def test_explicit_tone_educational(self, runner, mocks, tmp_path):
+        """--tone educational is accepted and displayed."""
+        result = self._invoke(runner, mocks, tmp_path, ["--tone", "educational"])
+        assert result.exit_code == 0
+        assert "educational" in result.output
+
+    def test_invalid_tone_rejected(self, runner, tmp_path):
+        """Invalid --tone value is rejected by Click."""
+        from zerg.commands.document import document
+
+        target = tmp_path / "module.py"
+        target.write_text("# module")
+
+        result = runner.invoke(document, [str(target), "--tone", "bogus"])
+        assert result.exit_code != 0
+        assert "Invalid value" in result.output or "invalid choice" in result.output.lower()
+
+    def test_tone_definition_files_exist(self):
+        """All tone definition files exist at expected paths."""
+        tones_dir = Path("zerg/data/tones")
+        for tone in ["educational", "reference", "tutorial"]:
+            tone_file = tones_dir / f"{tone}.md"
+            assert tone_file.exists(), f"Missing tone file: {tone_file}"

--- a/zerg/commands/document.py
+++ b/zerg/commands/document.py
@@ -38,6 +38,12 @@ logger = get_logger("document")
     is_flag=True,
     help="Update existing documentation in-place",
 )
+@click.option(
+    "--tone",
+    type=click.Choice(["educational", "reference", "tutorial"]),
+    default="educational",
+    help="Documentation tone (default: educational)",
+)
 @click.pass_context
 def document(
     ctx: click.Context,
@@ -46,6 +52,7 @@ def document(
     output: str | None,
     depth: str,
     update: bool,
+    tone: str,
 ) -> None:
     """Generate documentation for a specific component, module, or command.
 
@@ -73,6 +80,7 @@ def document(
             raise SystemExit(1)
 
         console.print(f"\n[bold cyan]ZERG Document[/bold cyan] - {target}\n")
+        console.print(f"Tone: [cyan]{tone}[/cyan]")
 
         # 1. Detect component type
         detector = ComponentDetector()

--- a/zerg/data/commands/design.core.md
+++ b/zerg/data/commands/design.core.md
@@ -186,6 +186,28 @@ Final polish.
 - Lint fixes
 ```
 
+### Mandatory Documentation Tasks
+
+Every task graph MUST include these documentation tasks. This is non-negotiable.
+
+#### CHANGELOG.md (ALWAYS Required)
+
+Every task graph MUST include a CHANGELOG.md update task in Level 5 (Quality). This task:
+- Updates the `[Unreleased]` section with entries for all changes in this feature
+- Uses categories: Added, Changed, Fixed, Removed
+- Depends on all testing-phase tasks
+
+#### Doc Update Tasks (Conditional)
+
+When a feature changes command/flag functionality, the task graph MUST also include tasks to update:
+- `README.md` — if CLI usage examples change
+- `docs/commands-quick.md` and `docs/commands-deep.md` — if command flags change
+- `.gsd/wiki/Command-Reference.md` — if user-facing commands change
+- `.gsd/wiki/Tutorial.md` — if workflows change
+- `CLAUDE.md` — if project conventions change
+
+These doc update tasks go in Level 4 or 5 (after implementation/testing, before or alongside quality).
+
 ### File Ownership Matrix
 
 Critical for parallel execution: each file is owned by ONE task.

--- a/zerg/data/commands/design.md
+++ b/zerg/data/commands/design.md
@@ -121,8 +121,31 @@ Depends on Integration.
 Final polish.
 - Documentation
 - Type coverage
+- CHANGELOG.md update (required — add entries under [Unreleased])
 - Lint fixes
 ```
+
+### Mandatory Documentation Tasks
+
+Every task graph MUST include these documentation tasks. This is non-negotiable.
+
+#### CHANGELOG.md (ALWAYS Required)
+
+Every task graph MUST include a CHANGELOG.md update task in Level 5 (Quality). This task:
+- Updates the `[Unreleased]` section with entries for all changes in this feature
+- Uses categories: Added, Changed, Fixed, Removed
+- Depends on all testing-phase tasks
+
+#### Doc Update Tasks (Conditional)
+
+When a feature changes command/flag functionality, the task graph MUST also include tasks to update:
+- `README.md` — if CLI usage examples change
+- `docs/commands-quick.md` and `docs/commands-deep.md` — if command flags change
+- `.gsd/wiki/Command-Reference.md` — if user-facing commands change
+- `.gsd/wiki/Tutorial.md` — if workflows change
+- `CLAUDE.md` — if project conventions change
+
+These doc update tasks go in Level 4 or 5 (after implementation/testing, before or alongside quality).
 
 ### File Ownership Matrix
 
@@ -588,6 +611,7 @@ Reply with:
 - User has explicitly approved
 - Claude Tasks created for all tasks with correct dependencies
 - Consumer matrix populated for all tasks with created files
+- Task graph includes a CHANGELOG.md update task in the final quality level
 
 ## Help
 

--- a/zerg/data/commands/document.md
+++ b/zerg/data/commands/document.md
@@ -9,6 +9,7 @@ Generate documentation for a specific component, module, or command.
                         [--output PATH]
                         [--depth shallow|standard|deep]
                         [--update]
+                        [--tone educational|reference|tutorial]
 ```
 
 ## Arguments
@@ -30,6 +31,19 @@ Generate documentation for a specific component, module, or command.
   - `standard` - Public API + key internals
   - `deep` - Full documentation with examples
 - `--update`: Update existing documentation in-place
+- `--tone`: Documentation tone. Default: `educational`
+  - `educational` - Concept-first with CONCEPT, NARRATIVE, DIAGRAM, COMMAND sections (default)
+  - `reference` - Terse tables and API signatures for quick lookup
+  - `tutorial` - Step-by-step walkthrough with simulated dialogues
+
+## Tone
+
+The `--tone` flag controls the documentation style. Before generating documentation, read the tone definition file at `zerg/data/tones/{tone}.md` and follow its style guidelines, required sections, and output structure template.
+
+Available tones:
+- **educational** (default): Every concept gets CONCEPT, NARRATIVE, DIAGRAM, COMMAND sections. Teaches "why" not just "what".
+- **reference**: Terse tables, API signatures, parameter lists. Quick lookup format.
+- **tutorial**: Step-by-step walkthrough with numbered steps, expected output, and troubleshooting.
 
 ## Pipeline
 
@@ -114,5 +128,7 @@ Flags:
   --depth shallow|standard|deep
                     Documentation depth (default: standard)
   --update          Update existing documentation in-place
+  --tone educational|reference|tutorial
+                    Documentation tone (default: educational)
   --help            Show this help message
 ```

--- a/zerg/data/commands/plan.core.md
+++ b/zerg/data/commands/plan.core.md
@@ -5,13 +5,19 @@ Capture complete requirements for feature: **$ARGUMENTS**
 
 ## ⛔ WORKFLOW BOUNDARY (NON-NEGOTIABLE)
 
+**CRITICAL: This is a PLANNING-ONLY command. You MUST NEVER write code, create files, or implement anything.**
+
 This command MUST NEVER:
 - Automatically run `/z:design` or any design phase
 - Automatically proceed to implementation
 - Call the Skill tool to invoke another command
 - Write code or make code changes
+- Create, modify, or delete source files
+- Run implementation tools (Write, Edit, Bash for code changes)
 
 After Phase 5.5 completes, the command STOPS. The user must manually run `/z:design`.
+
+**If you find yourself about to write code or create files: STOP IMMEDIATELY. You are in planning mode.**
 
 ## Flags
 
@@ -131,6 +137,8 @@ Before asking questions, understand the current state:
 2. **Explore Codebase** — List directory structure, read key files, identify patterns
 3. **Search for Similar Patterns** — How are existing features structured?
 
+> ⛔ **IMPLEMENTATION GUARD**: You are gathering requirements. DO NOT write code, DO NOT create implementation files, DO NOT design architecture. Stay in requirements-gathering mode.
+
 ### Phase 2: Requirements Elicitation
 
 Ask clarifying questions grouped logically. Don't ask everything at once. Cover:
@@ -149,6 +157,8 @@ See details file for the full template.
 
 Identify additional infrastructure needs (services, MCP servers, env vars, resources).
 Update `.gsd/INFRASTRUCTURE.md` if needed.
+
+> ⛔ **IMPLEMENTATION GUARD**: You are presenting requirements for approval. DO NOT proceed to design or implementation. DO NOT invoke /z:design. DO NOT write any code. After approval, output the PLANNING COMPLETE banner and STOP.
 
 ### Phase 5: User Approval
 
@@ -181,6 +191,22 @@ Based on user response:
 - **"Stop here"**: Command completes normally with no further output.
 
 **⛔ DO NOT auto-run /z:design. DO NOT write code. The user must manually invoke the next command.**
+
+Output this banner to the user:
+
+```
+═══════════════════════════════════════════════════════════════
+                    ⛔ PLANNING COMPLETE ⛔
+═══════════════════════════════════════════════════════════════
+
+This command has finished. DO NOT proceed to implementation.
+The user must manually run /z:design to continue.
+
+EXIT NOW — do not write code, do not invoke other commands.
+═══════════════════════════════════════════════════════════════
+```
+
+**After outputting this banner, the command is DONE. Do not take any further action. Do not write code. Do not call any tools. STOP.**
 
 ---
 

--- a/zerg/data/commands/plan.details.md
+++ b/zerg/data/commands/plan.details.md
@@ -312,6 +312,28 @@ After implementation, execute `/zerg:document` to update all documentation surfa
 - Ensure all ZERG commands and flags are accounted for in documentation
 - Wiki command pages must follow the `zerg-*.md` naming convention (non-command pages unaffected)
 - Before executing documentation updates, plan the work via `/zerg:design` and estimate via `/zerg:estimate`
+
+---
+
+## 11. Documentation Impact Analysis
+
+### 11.1 Files Requiring Documentation Updates
+| File | Current State | Required Update | Priority |
+|------|--------------|-----------------|----------|
+| `CHANGELOG.md` | | | Must |
+| `README.md` | | | |
+| `docs/commands-quick.md` | | | |
+| `docs/commands-deep.md` | | | |
+| `.gsd/wiki/Command-Reference.md` | | | |
+| `.gsd/wiki/Tutorial.md` | | | |
+| `CLAUDE.md` | | | |
+
+### 11.2 Documentation Tasks for Design Phase
+- [ ] CHANGELOG.md update task (ALWAYS required)
+- [ ] README.md update (if applicable)
+- [ ] Command reference updates (if command/flag functionality changed)
+- [ ] CLAUDE.md update (if project conventions changed)
+- [ ] Wiki updates (if user-facing behavior changed)
 ```
 
 ---

--- a/zerg/data/commands/plan.md
+++ b/zerg/data/commands/plan.md
@@ -5,18 +5,25 @@ Capture complete requirements for feature: **$ARGUMENTS**
 
 ## ⛔ WORKFLOW BOUNDARY (NON-NEGOTIABLE)
 
+**CRITICAL: This is a PLANNING-ONLY command. You MUST NEVER write code, create files, or implement anything.**
+
 This command MUST NEVER:
 - Automatically run `/z:design` or any design phase
 - Automatically proceed to implementation
 - Call the Skill tool to invoke another command
 - Write code or make code changes
+- Create, modify, or delete source files
+- Run implementation tools (Write, Edit, Bash for code changes)
 
 After Phase 5.5 completes, the command STOPS. The user must manually run `/z:design`.
+
+**If you find yourself about to write code or create files: STOP IMMEDIATELY. You are in planning mode.**
 
 ## Flags
 
 - `--socratic` or `-s`: Use structured 3-round discovery mode (see details file)
 - `--rounds N`: Number of rounds (default: 3, max: 5)
+- `--skip-validation`: Skip Phase 0 pre-execution validation checks
 
 ## Pre-Flight
 
@@ -82,6 +89,8 @@ Before asking questions, understand the current state:
 2. **Explore Codebase** — List directory structure, read key files, identify patterns
 3. **Search for Similar Patterns** — How are existing features structured?
 
+> ⛔ **IMPLEMENTATION GUARD**: You are gathering requirements. DO NOT write code, DO NOT create implementation files, DO NOT design architecture. Stay in requirements-gathering mode.
+
 ### Phase 2: Requirements Elicitation
 
 Ask clarifying questions grouped logically. Don't ask everything at once. Cover:
@@ -100,6 +109,8 @@ See details file for the full template.
 
 Identify additional infrastructure needs (services, MCP servers, env vars, resources).
 Update `.gsd/INFRASTRUCTURE.md` if needed.
+
+> ⛔ **IMPLEMENTATION GUARD**: You are presenting requirements for approval. DO NOT proceed to design or implementation. DO NOT invoke /z:design. DO NOT write any code. After approval, output the PLANNING COMPLETE banner and STOP.
 
 ### Phase 5: User Approval
 
@@ -132,6 +143,22 @@ Based on user response:
 - **"Stop here"**: Command completes normally with no further output.
 
 **⛔ DO NOT auto-run /z:design. DO NOT write code. The user must manually invoke the next command.**
+
+Output this banner to the user:
+
+```
+═══════════════════════════════════════════════════════════════
+                    ⛔ PLANNING COMPLETE ⛔
+═══════════════════════════════════════════════════════════════
+
+This command has finished. DO NOT proceed to implementation.
+The user must manually run /z:design to continue.
+
+EXIT NOW — do not write code, do not invoke other commands.
+═══════════════════════════════════════════════════════════════
+```
+
+**After outputting this banner, the command is DONE. Do not take any further action. Do not write code. Do not call any tools. STOP.**
 
 ---
 

--- a/zerg/data/tones/educational.md
+++ b/zerg/data/tones/educational.md
@@ -1,0 +1,137 @@
+# Educational Tone
+
+**Default tone for `/zerg:document`.**
+
+Teaches "why" not just "what". Every concept gets a plain-language explanation, a narrative connecting it to the bigger picture, a Mermaid diagram, and concrete CLI examples.
+
+## When to Use
+
+- New users learning ZERG for the first time
+- Onboarding documentation
+- Concept-heavy components where understanding matters more than quick reference
+- Any documentation where the reader needs to understand the reasoning behind design decisions
+
+## Required Sections Per Concept
+
+Every concept or component documented in this tone MUST include these four sections:
+
+### CONCEPT
+
+A plain-language explanation of what this thing is and why it exists. No jargon without definition. Answer: "What problem does this solve?"
+
+- Start with a one-sentence summary
+- Explain the problem it addresses
+- Define any domain-specific terms
+- State the key insight or principle
+
+### NARRATIVE
+
+Connect this concept to the bigger picture. How does it fit into the overall system? What comes before and after it in the workflow?
+
+- Explain the context: what triggers this, what depends on it
+- Describe the relationship to other components
+- Use analogies where helpful
+- Keep it conversational but precise
+
+### DIAGRAM
+
+A Mermaid diagram showing the concept's relationships, data flow, or lifecycle.
+
+- Use `graph TD` for dependency/flow diagrams
+- Use `sequenceDiagram` for interaction sequences
+- Use `stateDiagram-v2` for state transitions
+- Keep diagrams focused (5-10 nodes max)
+- Label edges with action descriptions
+
+### COMMAND
+
+Concrete CLI examples showing how to use or interact with this concept.
+
+- Show the most common usage first
+- Include expected output where helpful
+- Show at least one variation or option
+- Use real file paths from the project, not placeholders
+
+## Output Structure Template
+
+```markdown
+# {Component Title}
+
+> One-sentence summary of what this component does.
+
+## CONCEPT
+
+{Plain-language explanation of what this is and why it exists.}
+
+## NARRATIVE
+
+{How this fits into the bigger picture. What comes before/after. Relationships.}
+
+## DIAGRAM
+
+```mermaid
+graph TD
+    A["{Related Component}"] --> B["{This Component}"]
+    B --> C["{Downstream Component}"]
+```
+
+## COMMAND
+
+```bash
+# Primary usage
+{command example}
+
+# With options
+{command example with flags}
+```
+
+---
+
+{Repeat CONCEPT/NARRATIVE/DIAGRAM/COMMAND for each additional concept in the component.}
+```
+
+## Example Output
+
+```markdown
+# ZERG Launcher
+
+> Spawns and manages parallel Claude Code worker processes.
+
+## CONCEPT
+
+The Launcher is ZERG's process manager. When you run `/zerg:rush`, the Launcher takes the task graph and spawns one Claude Code instance per worker, each in its own git worktree. It handles three execution modes: Task (in-process subagents), Subprocess (local Python processes), and Container (Docker containers).
+
+Think of it as a foreman on a construction site: it assigns workers to tasks, makes sure they have the right tools, and reports back when they finish.
+
+## NARRATIVE
+
+The Launcher sits between the Orchestrator (which decides what to build) and the Workers (which do the building). After `/zerg:design` produces a task-graph.json, and `/zerg:rush` triggers execution, the Orchestrator calls the Launcher to spawn workers for each level.
+
+The Launcher is the only component that interacts with the operating system to create processes. Everything upstream is pure planning; everything downstream is pure execution.
+
+## DIAGRAM
+
+```mermaid
+graph TD
+    O["Orchestrator"] -->|"spawn(task, mode)"| L["Launcher"]
+    L -->|"Task mode"| T["Task Tool Subagent"]
+    L -->|"Subprocess mode"| S["Python Process"]
+    L -->|"Container mode"| D["Docker Container"]
+    T --> W["Worker Execution"]
+    S --> W
+    D --> W
+```
+
+## COMMAND
+
+```bash
+# Default: Task mode (in-process subagents)
+/zerg:rush --workers 5
+
+# Subprocess mode
+/zerg:rush --workers 3 --mode subprocess
+
+# Container mode (requires Docker)
+/zerg:rush --workers 5 --mode container
+```
+```

--- a/zerg/data/tones/reference.md
+++ b/zerg/data/tones/reference.md
@@ -1,0 +1,123 @@
+# Reference Tone
+
+**Terse, table-driven documentation for quick lookup.**
+
+Preserves the current `/zerg:document` default behavior. API signatures, parameter tables, return types. Minimal prose — just the facts.
+
+## When to Use
+
+- Experienced users who know the concepts and need quick reference
+- API documentation for developers integrating with ZERG
+- Configuration reference pages
+- Changelog and release notes
+
+## Style Guidelines
+
+- Lead with a one-line summary, no more
+- Use tables for parameters, options, return values, and enums
+- Use inline code for all identifiers, paths, and values
+- No analogies, no narrative, no diagrams unless structurally necessary
+- Group by category (public API, internals, configuration)
+- Alphabetize within groups when practical
+
+## Required Sections
+
+### Summary
+
+One sentence. What it is, what it does.
+
+### API Table
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+
+### Return Value
+
+Type and brief description.
+
+### Examples
+
+Minimal code showing primary usage. No explanation — the code speaks.
+
+## Output Structure Template
+
+```markdown
+# {Component Title}
+
+{One-sentence summary.}
+
+## Public API
+
+### `{function_name}({args}) -> {return_type}`
+
+{One-line description.}
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `{param}` | `{type}` | `{default}` | {description} |
+
+**Returns**: `{type}` — {description}
+
+**Raises**: `{exception}` — {when}
+
+### `{class_name}`
+
+{One-line description.}
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `{method}` | `({args}) -> {ret}` | {description} |
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `{key}` | `{type}` | `{default}` | {description} |
+
+## Examples
+
+```python
+{minimal usage example}
+```
+```
+
+## Example Output
+
+```markdown
+# zerg.launcher
+
+Spawns and manages parallel Claude Code worker processes.
+
+## Public API
+
+### `Launcher(config: ZergConfig)`
+
+Process manager for ZERG worker instances.
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `spawn` | `(task: Task, mode: str) -> Worker` | Spawn a worker for a task |
+| `stop` | `(worker_id: str) -> None` | Stop a running worker |
+| `status` | `() -> list[WorkerStatus]` | Get status of all workers |
+
+### `spawn(task, mode) -> Worker`
+
+Spawn a single worker process.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `task` | `Task` | — | Task from task-graph.json |
+| `mode` | `str` | `"task"` | Execution mode: task, subprocess, container |
+
+**Returns**: `Worker` — Handle to the spawned worker process.
+
+**Raises**: `LaunchError` — If worker fails to start.
+
+## Examples
+
+```python
+from zerg.launcher import Launcher
+launcher = Launcher(config)
+worker = launcher.spawn(task, mode="subprocess")
+```
+```

--- a/zerg/data/tones/tutorial.md
+++ b/zerg/data/tones/tutorial.md
@@ -1,0 +1,205 @@
+# Tutorial Tone
+
+**Step-by-step walkthrough with simulated dialogues and progressive complexity.**
+
+Guides the reader through using a component from zero to proficiency. Shows what to type, what to expect, and what to do when things go wrong.
+
+## When to Use
+
+- Getting-started guides
+- Feature walkthroughs for first-time use
+- Workflow tutorials that span multiple commands
+- Troubleshooting guides where step order matters
+
+## Style Guidelines
+
+- Number every step
+- Show the exact command and its expected output
+- Build complexity progressively: basic usage first, then options, then advanced
+- Include "What you should see" after each command
+- Use simulated terminal dialogues to show interactive flows
+- Add "Checkpoint" boxes after major milestones
+- Include "If something goes wrong" callouts for common failure modes
+
+## Required Sections
+
+### Prerequisites
+
+What the reader needs before starting. Software, configuration, prior knowledge.
+
+### Steps
+
+Numbered sequence of actions. Each step has:
+1. What to do (command or action)
+2. What you should see (expected output)
+3. Why this matters (one sentence)
+
+### Checkpoints
+
+After every 3-5 steps, a verification that the reader is on track.
+
+### Troubleshooting
+
+Common problems and their solutions, tied to specific steps.
+
+## Output Structure Template
+
+```markdown
+# Tutorial: {Title}
+
+> {What the reader will learn/accomplish by the end.}
+
+## Prerequisites
+
+- {Requirement 1}
+- {Requirement 2}
+
+## Step 1: {Action Title}
+
+{Brief explanation of what we're doing and why.}
+
+```bash
+$ {command}
+{expected output}
+```
+
+## Step 2: {Action Title}
+
+{Brief explanation.}
+
+```bash
+$ {command}
+{expected output}
+```
+
+## Step 3: {Action Title}
+
+{Brief explanation.}
+
+```bash
+$ {command}
+{expected output}
+```
+
+> **Checkpoint**: At this point you should have {verification criteria}. Run `{check command}` to confirm.
+
+## Step 4: {Action Title}
+
+{Now building on the basics...}
+
+```bash
+$ {command with options}
+{expected output}
+```
+
+## Troubleshooting
+
+### "{Error message or symptom}"
+
+**Cause**: {Why this happens.}
+
+**Fix**: {What to do.}
+
+```bash
+$ {fix command}
+```
+
+## Next Steps
+
+- {What to learn next}
+- {Related tutorial}
+```
+
+## Example Output
+
+```markdown
+# Tutorial: Your First ZERG Rush
+
+> By the end of this tutorial, you'll plan, design, and execute a feature using parallel workers.
+
+## Prerequisites
+
+- Claude Code CLI installed and authenticated
+- A git repository with ZERG initialized (`/zerg:init` completed)
+- At least 5 minutes of uninterrupted time
+
+## Step 1: Plan the Feature
+
+Every ZERG feature starts with a plan. Tell ZERG what you want to build:
+
+```bash
+$ /zerg:plan user-notifications
+```
+
+ZERG will ask you clarifying questions about your feature. Answer them — this builds the requirements document.
+
+```
+═══════════════════════════════════════════════════════════════
+                 REQUIREMENTS READY FOR REVIEW
+═══════════════════════════════════════════════════════════════
+
+Feature: user-notifications
+Summary:
+  - 8 functional requirements (5 must / 2 should / 1 could)
+  - 3 test scenarios
+
+Reply with: "APPROVED" or "REJECTED"
+═══════════════════════════════════════════════════════════════
+```
+
+Type `APPROVED` to lock in the requirements.
+
+## Step 2: Design the Architecture
+
+Now ZERG creates the technical design and task graph:
+
+```bash
+$ /zerg:design
+```
+
+You'll see the architecture, file ownership matrix, and task dependency graph. Review it carefully — this is the blueprint for parallel execution.
+
+## Step 3: Launch the Swarm
+
+Time to execute. Launch 3 parallel workers:
+
+```bash
+$ /zerg:rush --workers 3
+```
+
+> **Checkpoint**: Run `/zerg:status` to verify all Level 1 tasks are in progress. You should see 3 workers active.
+
+## Step 4: Monitor Progress
+
+While workers execute, check status:
+
+```bash
+$ /zerg:status
+
+Feature: user-notifications
+Workers: 3 active
+
+Level 1 (foundation): ████████████ 100% [3/3 complete]
+Level 2 (core):       ████░░░░░░░░  33% [1/3 in progress]
+```
+
+## Troubleshooting
+
+### "ERROR: Task graph not found"
+
+**Cause**: You skipped the design phase.
+
+**Fix**: Run `/zerg:design` first, then retry `/zerg:rush`.
+
+### "Worker failed: verification command exit code 1"
+
+**Cause**: The worker's code didn't pass its verification check.
+
+**Fix**: Run `/zerg:retry` to re-attempt failed tasks, or `/zerg:debug {task-id}` to investigate.
+
+## Next Steps
+
+- Learn about container mode: `/zerg:rush --mode container`
+- Customize quality gates in `.zerg/config.yaml`
+- Try `/zerg:review` for automated code review after completion
+```


### PR DESCRIPTION
## Summary
- **#129**: Add `--tone educational|reference|tutorial` flag to `/zerg:document` with 3 tone definition files (educational, reference, tutorial)
- **#163**: Harden `/zerg:plan` anti-implementation guards — 6 guard points across core/details preventing premature code generation
- **#165**: Add documentation impact tracking — Section 11 in plan requirements template + mandatory doc tasks in `/zerg:design`

## Changes
- 3 new tone definition files (`zerg/data/tones/`)
- `--tone` Click option on `document.py` with CLI validation
- 4 strengthened guards in `plan.core.md` and `plan.md`
- Section 11 (Documentation Impact Analysis) in `plan.details.md`
- Mandatory CHANGELOG task in `design.core.md` and `design.md`
- 6 new unit tests for tone validation
- Updated CHANGELOG, README, CLAUDE.md, wiki, and command docs

## Test plan
- [x] 6 new unit tests pass (`tests/unit/test_document_tone.py`)
- [x] All 33 tests pass (`pytest`)
- [x] `validate_commands` passes
- [x] Pre-commit hooks pass (ruff, ruff format)
- [x] Two-stage code review completed (spec compliance + code quality)

Closes #129, closes #163, closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)