### PR TITLE
fix: add github-actions ecosystem to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,12 @@ updates:
       - "dependencies"
     reviewers:
       - "rocklambros"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci-cd"
+    reviewers:
+      - "rocklambros"


### PR DESCRIPTION
## Summary

- Add `github-actions` package ecosystem to `.github/dependabot.yml` for automated CI action version updates
- Completes remaining item from #187

## Test plan

- [ ] Dependabot config is valid YAML
- [ ] Weekly schedule for github-actions updates alongside existing pip updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)