### PR TITLE
feat: post-release polish — sponsors, release notes, link checker, pre-commit

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: rocklambros
+# buy_me_a_coffee:
+# open_collective:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+      - duplicate
+  categories:
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,27 @@ jobs:
           # Run pip-audit without --strict since local package (zerg) isn't on PyPI
           # This still catches actual vulnerabilities in dependencies
           pip-audit --desc
+
+  link-check:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check documentation links
+        uses: lychee/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --retry-wait-time 5
+            --max-retries 3
+            --timeout 30
+            --exclude 'localhost'
+            --exclude '127\.0\.0\.1'
+            --exclude 'example\.com'
+            --exclude 'img\.shields\.io/pypi'
+            docs/**/*.md
+            README.md
+            CONTRIBUTING.md
+            CHANGELOG.md
+          fail: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,13 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-toml
+      - id: check-added-large-files
+        args: ['--maxkb=500']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `.github/FUNDING.yml` for GitHub Sponsors (#191)
+- `.github/release.yml` for auto-categorized release notes (#191)
+- `lychee` link checker CI job for documentation (#191)
+
+### Changed
+
+- Pre-commit config expanded with 6 standard hooks (`trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-json`, `check-toml`, `check-added-large-files`) (#191)
+
 ## [0.2.0] - 2026-02-07
 
 ### Added


### PR DESCRIPTION
## Summary

Closes #191. Post-v0.2.0 polish — four independent infrastructure improvements:

- **`.github/FUNDING.yml`** — enables GitHub Sponsors button (`github: rocklambros`)
- **`.github/release.yml`** — auto-categorized release notes (5 categories: New Features, Bug Fixes, Documentation, Dependencies, Other Changes; excludes `skip-changelog`/`duplicate` labels)
- **`lychee` link checker CI job** — non-blocking (`continue-on-error: true`) documentation link validation with retries, timeouts, and exclude patterns
- **Pre-commit expansion** — 6 standard hooks added (`trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-json`, `check-toml`, `check-added-large-files`)

## Test plan

- [ ] CI passes (existing `quality`, `smoke`, `test`, `audit` jobs unaffected)
- [ ] New `link-check` job runs and reports results (non-blocking)
- [ ] `pre-commit run --all-files` passes with 8 hooks
- [ ] `.github/FUNDING.yml` enables Sponsor button on repo
- [ ] `.github/release.yml` categories visible in next release draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)