### PR TITLE
docs: link command cheat sheet to wiki Command-Reference

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -635,8 +635,8 @@
         </div>
 
         <div class="text-center">
-          <a href="https://github.com/rocklambros/zerg/wiki" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 text-sm font-semibold transition-opacity hover:opacity-80" style="color: var(--accent-purple);">
-            Full documentation
+          <a href="https://github.com/rocklambros/zerg/wiki/Command-Reference" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 text-sm font-semibold transition-opacity hover:opacity-80" style="color: var(--accent-purple);">
+            Detailed command reference
             <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <line x1="5" y1="12" x2="19" y2="12"></line>
               <polyline points="12 5 19 12 12 19"></polyline>


### PR DESCRIPTION
## Summary
- Updated the commands section link from generic "Full documentation" → "Detailed command reference"
- Now points to `wiki/Command-Reference` instead of the wiki root

## Test plan
- [ ] Verify link text reads "Detailed command reference"
- [ ] Verify link opens wiki Command-Reference page

🤖 Generated with [Claude Code](https://claude.com/claude-code)