### PR TITLE
docs: add Docs link to nav header

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -85,6 +85,7 @@
           <a href="#commands" class="text-sm font-medium hover:opacity-80 transition-opacity" style="color: var(--text-secondary);">Commands</a>
           <a href="#quickstart" class="text-sm font-medium hover:opacity-80 transition-opacity" style="color: var(--text-secondary);">Quick Start</a>
           <a href="#faq" class="text-sm font-medium hover:opacity-80 transition-opacity" style="color: var(--text-secondary);">FAQ</a>
+          <a href="https://github.com/rocklambros/zerg/wiki" target="_blank" rel="noopener noreferrer" class="text-sm font-medium hover:opacity-80 transition-opacity" style="color: var(--text-secondary);">Docs</a>
         </div>
 
         <!-- Right: Theme Toggle + GitHub + Mobile Menu -->
@@ -136,6 +137,7 @@
           <a href="#commands" class="px-3 py-2 rounded-lg text-sm font-medium transition-colors" style="color: var(--text-secondary);">Commands</a>
           <a href="#quickstart" class="px-3 py-2 rounded-lg text-sm font-medium transition-colors" style="color: var(--text-secondary);">Quick Start</a>
           <a href="#faq" class="px-3 py-2 rounded-lg text-sm font-medium transition-colors" style="color: var(--text-secondary);">FAQ</a>
+          <a href="https://github.com/rocklambros/zerg/wiki" target="_blank" rel="noopener noreferrer" class="px-3 py-2 rounded-lg text-sm font-medium transition-colors" style="color: var(--text-secondary);">Docs</a>
           <a href="https://github.com/rocklambros/zerg" target="_blank" rel="noopener noreferrer" class="px-3 py-2 rounded-lg text-sm font-medium flex items-center gap-2 transition-colors" style="color: var(--text-secondary);" aria-label="View ZERG on GitHub">
             <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>


### PR DESCRIPTION
## Summary
- Added "Docs" link to desktop and mobile nav, pointing to the wiki

## Test plan
- [ ] Verify "Docs" appears in desktop nav between FAQ and GitHub
- [ ] Verify "Docs" appears in mobile hamburger menu
- [ ] Verify link opens wiki in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)