### PR TITLE
fix: restore alternating section shading after Quick Start reorder

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -397,7 +397,7 @@ pip install zerg-ai
     <!-- ================================================================
          Section 4: How It Works
          ================================================================ -->
-    <section id="how" class="py-20 px-4 sm:px-6 lg:px-8 fade-in" role="region" aria-labelledby="how-heading">
+    <section id="how" class="py-20 px-4 sm:px-6 lg:px-8 fade-in" style="background: var(--bg-secondary);" role="region" aria-labelledby="how-heading">
       <div class="max-w-5xl mx-auto">
         <h2 id="how-heading" class="text-3xl sm:text-4xl font-bold text-center mb-16" style="color: var(--text-primary);">
           How It <span class="gradient-text">Works</span>
@@ -468,7 +468,7 @@ pip install zerg-ai
     <!-- ================================================================
          Section 5: Commands Cheat Sheet
          ================================================================ -->
-    <section id="commands" class="py-20 px-4 sm:px-6 lg:px-8 fade-in" style="background: var(--bg-secondary);" role="region" aria-labelledby="commands-heading">
+    <section id="commands" class="py-20 px-4 sm:px-6 lg:px-8 fade-in" role="region" aria-labelledby="commands-heading">
       <div class="max-w-5xl mx-auto">
         <h2 id="commands-heading" class="text-3xl sm:text-4xl font-bold text-center mb-4" style="color: var(--text-primary);">
           <span class="gradient-text">26 Commands</span>. One Toolkit.


### PR DESCRIPTION
## Summary
- Added `--bg-secondary` to How It Works section
- Removed `--bg-secondary` from Commands section
- Restores proper alternating background pattern after #213 moved Quick Start

## Test plan
- [ ] Verify sections alternate between default and shaded backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)