### PR TITLE
fix: correct license to MIT

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -40,7 +40,7 @@
       "price": "0",
       "priceCurrency": "USD"
     },
-    "license": "https://opensource.org/licenses/Apache-2.0"
+    "license": "https://opensource.org/licenses/MIT"
   }
   </script>
 
@@ -772,7 +772,7 @@ pip install zerg-ai
               <span class="chevron" aria-hidden="true">&#x203A;</span>
             </summary>
             <div class="faq-answer">
-              <p>ZERG is open source under the Apache 2.0 license. You'll need your own Anthropic API key or Claude Pro/Team subscription for the Claude Code instances.</p>
+              <p>ZERG is open source under the MIT license. You'll need your own Anthropic API key or Claude Pro/Team subscription for the Claude Code instances.</p>
             </div>
           </details>
 
@@ -824,7 +824,7 @@ pip install zerg-ai
           <a href="https://github.com/rocklambros/zerg" target="_blank" rel="noopener noreferrer" class="hover:opacity-80 transition-opacity" style="color: var(--text-secondary);">GitHub</a>
           <a href="https://github.com/rocklambros/zerg/wiki" target="_blank" rel="noopener noreferrer" class="hover:opacity-80 transition-opacity" style="color: var(--text-secondary);">Wiki</a>
           <a href="https://github.com/sponsors/rocklambros" target="_blank" rel="noopener noreferrer" class="hover:opacity-80 transition-opacity" style="color: var(--text-secondary);">Sponsor</a>
-          <a href="https://github.com/rocklambros/zerg/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" class="hover:opacity-80 transition-opacity" style="color: var(--text-secondary);">Apache 2.0</a>
+          <a href="https://github.com/rocklambros/zerg/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" class="hover:opacity-80 transition-opacity" style="color: var(--text-secondary);">MIT License</a>
         </div>
 
         <!-- Right: Attribution -->


### PR DESCRIPTION
## Summary
- Fixed footer link: Apache 2.0 → MIT License
- Fixed JSON-LD structured data: Apache-2.0 → MIT license URL
- Fixed FAQ answer: Apache 2.0 → MIT

## Test plan
- [ ] Verify footer shows "MIT License"
- [ ] Verify FAQ "Is it free?" mentions MIT

🤖 Generated with [Claude Code](https://claude.com/claude-code)