### PR TITLE
feat: add LinkedIn and X social links to header and footer

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -118,6 +118,20 @@
             <span>GitHub</span>
           </a>
 
+          <!-- LinkedIn Link -->
+          <a href="https://linkedin.com/in/rocklambros" target="_blank" rel="noopener noreferrer" class="hidden sm:flex items-center p-2 rounded-lg transition-colors" style="color: var(--text-muted);" aria-label="LinkedIn">
+            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+            </svg>
+          </a>
+
+          <!-- X (Twitter) Link -->
+          <a href="https://x.com/rocklambros" target="_blank" rel="noopener noreferrer" class="hidden sm:flex items-center p-2 rounded-lg transition-colors" style="color: var(--text-muted);" aria-label="X (Twitter)">
+            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+            </svg>
+          </a>
+
           <!-- Mobile Menu Button -->
           <button id="mobile-menu-btn" type="button" class="md:hidden p-2 rounded-lg transition-colors" style="color: var(--text-muted);" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobile-menu">
             <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -825,6 +839,16 @@ pip install zerg-ai
           <a href="https://github.com/rocklambros/zerg/wiki" target="_blank" rel="noopener noreferrer" class="hover:opacity-80 transition-opacity" style="color: var(--text-secondary);">Wiki</a>
           <a href="https://github.com/sponsors/rocklambros" target="_blank" rel="noopener noreferrer" class="hover:opacity-80 transition-opacity" style="color: var(--text-secondary);">Sponsor</a>
           <a href="https://github.com/rocklambros/zerg/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" class="hover:opacity-80 transition-opacity" style="color: var(--text-secondary);">MIT License</a>
+          <a href="https://linkedin.com/in/rocklambros" target="_blank" rel="noopener noreferrer" class="hover:opacity-80 transition-opacity" style="color: var(--text-secondary);" aria-label="LinkedIn">
+            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+            </svg>
+          </a>
+          <a href="https://x.com/rocklambros" target="_blank" rel="noopener noreferrer" class="hover:opacity-80 transition-opacity" style="color: var(--text-secondary);" aria-label="X (Twitter)">
+            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+            </svg>
+          </a>
         </div>
 
         <!-- Right: Attribution -->


### PR DESCRIPTION
## Summary
- Added LinkedIn icon linking to linkedin.com/in/rocklambros in header and footer
- Added X (Twitter) icon linking to x.com/rocklambros in header and footer

## Test plan
- [ ] Verify LinkedIn and X icons appear in desktop header next to GitHub
- [ ] Verify LinkedIn and X icons appear in footer
- [ ] Verify both links open correct profiles in new tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)