### PR TITLE
fix(commands): replace manual plan mode with EnterPlanMode/ExitPlanMode

### DIFF
--- a/.gsd/.current-feature
+++ b/.gsd/.current-feature
@@ -1,1 +1,1 @@
-zerg-website
+plan-mode-conflict-fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Plan mode deadlock in `/z:plan` — replaced manual "Shift+Tab" instruction with programmatic `EnterPlanMode`/`ExitPlanMode` tool calls
+- Skip-to-implement behavior after plan mode exit — added POST-EXIT GUARD sections to `/z:plan` and `/z:brainstorm`
+
 ## [0.2.1] - 2026-02-11
 
 ### Added

--- a/zerg/data/commands/brainstorm.core.md
+++ b/zerg/data/commands/brainstorm.core.md
@@ -85,6 +85,18 @@ This ensures the task system tracks the full lifecycle: start -> in_progress -> 
 
 ---
 
+## Enter Plan Mode
+
+Call the **EnterPlanMode** tool to enter Claude Code plan mode.
+
+Plan mode provides read-only tools for deep codebase exploration and research. You will stay
+in plan mode for Phases 1-2.7 (Research through YAGNI Gate), then exit before Phase 3 when
+you need to write files and create GitHub issues.
+
+⚠️ Do NOT attempt to write files or run Bash while in plan mode — those tools are restricted.
+
+---
+
 ## Workflow Overview
 
 ### Phase 1: Research
@@ -150,6 +162,33 @@ Runs in both modes. Present all identified features via AskUserQuestion (multiSe
 - Options: Each identified feature with one-line description
 
 Kept features → proceed to Phase 3. Dropped features → logged in `.gsd/specs/{session-id}/deferred.md`.
+
+## Exit Plan Mode (Before Phase 3)
+
+After completing Phase 2.7 (YAGNI Gate), you have completed all discovery. You now need to
+write files and create GitHub issues.
+
+Write your plan summarizing:
+- Research findings from Phase 1
+- Discovery insights from Phase 2
+- Trade-off decisions from Phase 2.5
+- Validated design from Phase 2.6
+- Features passing YAGNI Gate from Phase 2.7
+
+Then call **ExitPlanMode** to present the plan for approval.
+
+### ⛔ POST-EXIT GUARD (NON-NEGOTIABLE)
+
+After the user approves and plan mode exits, you are STILL inside `/z:brainstorm`.
+
+Your ONLY remaining tasks are:
+1. Phase 3: Save research/transcript files, create GitHub issues
+2. Phase 4: Present handoff recommendations and STOP
+
+**DO NOT implement features. DO NOT invoke /z:plan. DO NOT write code.**
+**You are completing the brainstorm workflow, not starting implementation.**
+
+---
 
 ### Phase 3: Issue Generation
 

--- a/zerg/data/commands/brainstorm.md
+++ b/zerg/data/commands/brainstorm.md
@@ -84,6 +84,18 @@ This ensures the task system tracks the full lifecycle: start -> in_progress -> 
 
 ---
 
+## Enter Plan Mode
+
+Call the **EnterPlanMode** tool to enter Claude Code plan mode.
+
+Plan mode provides read-only tools for deep codebase exploration and research. You will stay
+in plan mode for Phases 1-2.7 (Research through YAGNI Gate), then exit before Phase 3 when
+you need to write files and create GitHub issues.
+
+⚠️ Do NOT attempt to write files or run Bash while in plan mode — those tools are restricted.
+
+---
+
 ## Workflow Overview
 
 ### Phase 1: Research
@@ -149,6 +161,33 @@ Runs in both modes. Present all identified features via AskUserQuestion (multiSe
 - Options: Each identified feature with one-line description
 
 Kept features → proceed to Phase 3. Dropped features → logged in `.gsd/specs/{session-id}/deferred.md`.
+
+## Exit Plan Mode (Before Phase 3)
+
+After completing Phase 2.7 (YAGNI Gate), you have completed all discovery. You now need to
+write files and create GitHub issues.
+
+Write your plan summarizing:
+- Research findings from Phase 1
+- Discovery insights from Phase 2
+- Trade-off decisions from Phase 2.5
+- Validated design from Phase 2.6
+- Features passing YAGNI Gate from Phase 2.7
+
+Then call **ExitPlanMode** to present the plan for approval.
+
+### ⛔ POST-EXIT GUARD (NON-NEGOTIABLE)
+
+After the user approves and plan mode exits, you are STILL inside `/z:brainstorm`.
+
+Your ONLY remaining tasks are:
+1. Phase 3: Save research/transcript files, create GitHub issues
+2. Phase 4: Present handoff recommendations and STOP
+
+**DO NOT implement features. DO NOT invoke /z:plan. DO NOT write code.**
+**You are completing the brainstorm workflow, not starting implementation.**
+
+---
 
 ### Phase 3: Issue Generation
 

--- a/zerg/data/commands/plan.core.md
+++ b/zerg/data/commands/plan.core.md
@@ -99,9 +99,13 @@ Before proceeding, validate this plan hasn't been superseded:
 
 ## Enter Plan Mode
 
-**Press Shift+Tab twice** to enter plan mode (Opus 4.5 for reasoning).
+Call the **EnterPlanMode** tool to enter Claude Code plan mode.
 
-Plan mode gives you read-only tools to explore the codebase without making changes.
+Plan mode provides read-only tools (Glob, Grep, Read, WebSearch, AskUserQuestion) for deep
+codebase exploration. You will stay in plan mode for Phases 1-2, then exit before Phase 3
+when you need to write files.
+
+⚠️ Do NOT attempt to write files or run Bash while in plan mode — those tools are restricted.
 
 ---
 
@@ -146,6 +150,33 @@ Ask clarifying questions grouped logically. Don't ask everything at once. Cover:
 - Scope Boundaries, Dependencies, Acceptance Criteria
 
 See details file for full question categories.
+
+## Exit Plan Mode (Before Phase 3)
+
+After completing Phase 2, you have gathered all requirements through read-only exploration and
+user questions. You now need to write files.
+
+Write your plan summarizing:
+- Key findings from Phase 1 (codebase patterns, tech stack, existing conventions)
+- Requirements gathered from Phase 2 (functional, non-functional, scope, acceptance criteria)
+- Files to be created: `.gsd/specs/{feature}/requirements.md`
+
+Then call **ExitPlanMode** to present the plan for approval.
+
+### ⛔ POST-EXIT GUARD (NON-NEGOTIABLE)
+
+After the user approves and plan mode exits, you are STILL inside the `/z:plan` command.
+
+Your ONLY remaining tasks are:
+1. Phase 3: Write `requirements.md` to `.gsd/specs/{feature}/`
+2. Phase 4: Check infrastructure needs
+3. Phase 5: Present requirements for user approval
+4. Phase 5.5: Mark task complete and STOP
+
+**DO NOT implement the feature. DO NOT write code. DO NOT invoke /z:design.**
+**You are writing PLANNING DOCUMENTS, not implementing.**
+
+---
 
 ### Phase 3: Generate requirements.md
 

--- a/zerg/data/commands/plan.md
+++ b/zerg/data/commands/plan.md
@@ -51,9 +51,13 @@ echo "$(date -Iseconds)" > ".gsd/specs/$FEATURE/.started"
 
 ## Enter Plan Mode
 
-**Press Shift+Tab twice** to enter plan mode (Opus 4.5 for reasoning).
+Call the **EnterPlanMode** tool to enter Claude Code plan mode.
 
-Plan mode gives you read-only tools to explore the codebase without making changes.
+Plan mode provides read-only tools (Glob, Grep, Read, WebSearch, AskUserQuestion) for deep
+codebase exploration. You will stay in plan mode for Phases 1-2, then exit before Phase 3
+when you need to write files.
+
+⚠️ Do NOT attempt to write files or run Bash while in plan mode — those tools are restricted.
 
 ---
 
@@ -98,6 +102,33 @@ Ask clarifying questions grouped logically. Don't ask everything at once. Cover:
 - Scope Boundaries, Dependencies, Acceptance Criteria
 
 See details file for full question categories.
+
+## Exit Plan Mode (Before Phase 3)
+
+After completing Phase 2, you have gathered all requirements through read-only exploration and
+user questions. You now need to write files.
+
+Write your plan summarizing:
+- Key findings from Phase 1 (codebase patterns, tech stack, existing conventions)
+- Requirements gathered from Phase 2 (functional, non-functional, scope, acceptance criteria)
+- Files to be created: `.gsd/specs/{feature}/requirements.md`
+
+Then call **ExitPlanMode** to present the plan for approval.
+
+### ⛔ POST-EXIT GUARD (NON-NEGOTIABLE)
+
+After the user approves and plan mode exits, you are STILL inside the `/z:plan` command.
+
+Your ONLY remaining tasks are:
+1. Phase 3: Write `requirements.md` to `.gsd/specs/{feature}/`
+2. Phase 4: Check infrastructure needs
+3. Phase 5: Present requirements for user approval
+4. Phase 5.5: Mark task complete and STOP
+
+**DO NOT implement the feature. DO NOT write code. DO NOT invoke /z:design.**
+**You are writing PLANNING DOCUMENTS, not implementing.**
+
+---
 
 ### Phase 3: Generate requirements.md
 


### PR DESCRIPTION
## Summary

- Replace manual "Press Shift+Tab twice" instruction with programmatic `EnterPlanMode` tool call in `/z:plan` and `/z:brainstorm`
- Add `ExitPlanMode` sections between read-only and write phases
- Add POST-EXIT GUARD sections to prevent skip-to-implement behavior after plan mode exit

## Changes

| File | Change |
|------|--------|
| `plan.md` | Replace Enter Plan Mode, add Exit Plan Mode + POST-EXIT GUARD |
| `plan.core.md` | Same changes (split pair consistency) |
| `brainstorm.md` | Add Enter Plan Mode, add Exit Plan Mode + POST-EXIT GUARD |
| `brainstorm.core.md` | Same changes (split pair consistency) |
| `CHANGELOG.md` | Add Fixed entries under [Unreleased] |

## Test plan

- [x] `python -m zerg.validate_commands` passes (all checks green)
- [x] Split pairs consistent (14/14)
- [x] All 4 files contain EnterPlanMode, ExitPlanMode, POST-EXIT GUARD
- [x] Pre-existing warnings unchanged (no regressions)
- [x] All 9 functional requirements traced and covered